### PR TITLE
Add basic logic for finding the latest beta version for an iOS app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,39 @@
+name := "live-app-versions"
+
+organization := "com.gu"
+
+description:= "CHANGE_ME"
+
+version := "1.0"
+
+scalaVersion := "2.12.8"
+
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "UTF-8",
+  "-target:jvm-1.8",
+  "-Ywarn-dead-code"
+)
+
+val circeVersion = "0.12.3"
+
+libraryDependencies ++= Seq(
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.8.2",
+  "com.pauldijou" %% "jwt-core" % "4.2.0",
+  "com.squareup.okhttp3" % "okhttp" % "4.3.1",
+  "com.turo" % "pushy" % "0.13.9",
+  "io.circe" %% "circe-core" % circeVersion,
+  "io.circe" %% "circe-generic" % circeVersion,
+  "io.circe" %% "circe-parser" % circeVersion,
+  "org.slf4j" % "slf4j-api" % "1.7.30"
+)
+
+enablePlugins(RiffRaffArtifact)
+
+assemblyJarName := s"${name.value}.jar"
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffArtifactResources += (file("cfn.yaml"), s"${name.value}-cfn/cfn.yaml")

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "live-app-versions"
 
 organization := "com.gu"
 
-description:= "CHANGE_ME"
+description:= "Lambda function which retrieves the latest beta version from App Store Connect."
 
 version := "1.0"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
+
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%t] %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/scala/com/gu/liveappversions/AccessToken.scala
+++ b/src/main/scala/com/gu/liveappversions/AccessToken.scala
@@ -1,0 +1,24 @@
+package com.gu.liveappversions
+
+import java.time.ZonedDateTime
+
+import com.gu.liveappversions.Config.AppStoreConnectConfig
+import pdi.jwt.{ Jwt, JwtAlgorithm, JwtClaim, JwtHeader }
+
+object JwtTokenBuilder {
+
+  def buildToken(appStoreConnectConfig: AppStoreConnectConfig): String = {
+    val expires = ZonedDateTime.now.plusMinutes(20).toInstant.getEpochSecond
+    val header = new JwtHeader(
+      algorithm = Some(JwtAlgorithm.ES256),
+      typ = Some("typ"),
+      keyId = Some(appStoreConnectConfig.privateKeyId),
+      contentType = Some("application/json"))
+    val claim = JwtClaim(
+      issuer = Some(appStoreConnectConfig.issuerId),
+      expiration = Some(expires),
+      audience = Some(Set("appstoreconnect-v1")))
+    Jwt.encode(header = header, claim = claim, key = appStoreConnectConfig.privateKey)
+  }
+
+}

--- a/src/main/scala/com/gu/liveappversions/Config.scala
+++ b/src/main/scala/com/gu/liveappversions/Config.scala
@@ -18,7 +18,7 @@ object Config {
       Option(System.getenv("Stage")).getOrElse("DEV"))
   }
 
-  case class AppStoreConnectConfig(teamId: String, privateKeyId: String, issuerId: String, privateKey: ApnsSigningKey)
+  case class AppStoreConnectConfig(teamId: String, privateKeyId: String, issuerId: String, privateKey: ApnsSigningKey, appleAppId: String)
 
   object AppStoreConnectConfig {
     def apply(): AppStoreConnectConfig = {
@@ -31,7 +31,8 @@ object Config {
         privateKey = ApnsSigningKey.loadFromInputStream(
           new ByteArrayInputStream(System.getenv("APPSTORE_PRIVATE_KEY").getBytes(StandardCharsets.UTF_8)),
           teamId,
-          privateKeyId))
+          privateKeyId),
+        appleAppId = System.getenv("APPLE_APP_ID"))
     }
   }
 

--- a/src/main/scala/com/gu/liveappversions/Config.scala
+++ b/src/main/scala/com/gu/liveappversions/Config.scala
@@ -1,0 +1,38 @@
+package com.gu.liveappversions
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+import com.turo.pushy.apns.auth.ApnsSigningKey
+
+object Config {
+
+  case class Env(app: String, stack: String, stage: String) {
+    override def toString: String = s"App: $app, Stack: $stack, Stage: $stage\n"
+  }
+
+  object Env {
+    def apply(): Env = Env(
+      Option(System.getenv("App")).getOrElse("DEV"),
+      Option(System.getenv("Stack")).getOrElse("DEV"),
+      Option(System.getenv("Stage")).getOrElse("DEV"))
+  }
+
+  case class AppStoreConnectConfig(teamId: String, privateKeyId: String, issuerId: String, privateKey: ApnsSigningKey)
+
+  object AppStoreConnectConfig {
+    def apply(): AppStoreConnectConfig = {
+      val teamId = System.getenv("APPSTORE_TEAM_ID")
+      val privateKeyId = System.getenv("APPSTORE_PRIVATE_KEY_ID")
+      AppStoreConnectConfig(
+        teamId = teamId,
+        privateKeyId = privateKeyId,
+        issuerId = System.getenv("APPSTORE_ISSUER_ID"),
+        privateKey = ApnsSigningKey.loadFromInputStream(
+          new ByteArrayInputStream(System.getenv("APPSTORE_PRIVATE_KEY").getBytes(StandardCharsets.UTF_8)),
+          teamId,
+          privateKeyId))
+    }
+  }
+
+}

--- a/src/main/scala/com/gu/liveappversions/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/Lambda.scala
@@ -1,0 +1,68 @@
+package com.gu.liveappversions
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.gu.liveappversions.Config.{ AppStoreConnectConfig, Env }
+import org.slf4j.{ Logger, LoggerFactory }
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import io.circe.parser._
+
+import scala.util.Try
+
+object AppStoreConnectApi {
+
+  import io.circe.generic.auto._
+
+  case class BuildAttributes(version: String)
+  case class BuildDetails(id: String, attributes: BuildAttributes)
+  case class BetaBuildAttributes(externalBuildState: String)
+  case class BetaBuildDetails(id: String, attributes: BetaBuildAttributes)
+
+  case class BuildsResponse(data: List[BuildDetails], included: List[BetaBuildDetails])
+
+  val client = new OkHttpClient
+  val appStoreConnectBaseUrl = "https://api.appstoreconnect.apple.com/v1"
+
+  def findLatestBuildWithExternalTesters(buildsResponse: BuildsResponse): Option[BuildDetails] = {
+    val latestBetaWithExternalTesters = buildsResponse.included.find(_.attributes.externalBuildState == "IN_BETA_TESTING")
+    latestBetaWithExternalTesters.flatMap(betaBuild => buildsResponse.data.find(_.id == betaBuild.id))
+  }
+
+  def latestBuildWithExternalTesters(token: String): Option[BuildDetails] = {
+    val buildsQuery = "/builds?limit=20&sort=-version&include=buildBetaDetail&filter[app]=409128287"
+    val request = new Request.Builder()
+      .url(s"$appStoreConnectBaseUrl$buildsQuery")
+      .addHeader("Authorization", s"Bearer $token")
+      .build
+    for {
+      response <- Try(client.newCall(request).execute).toOption
+      parseAttempt <- decode[BuildsResponse](response.body().string()).toOption
+      build <- findLatestBuildWithExternalTesters(parseAttempt)
+    } yield build
+  }
+
+}
+
+object Lambda {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def handler(context: Context): Unit = {
+    val env = Env()
+    logger.info(s"Starting $env")
+    process()
+  }
+
+  def process(): Unit = {
+    val token = JwtTokenBuilder.buildToken(AppStoreConnectConfig())
+    val latestBuild = AppStoreConnectApi.latestBuildWithExternalTesters(token)
+    println(latestBuild)
+  }
+
+}
+
+object TestIt {
+  def main(args: Array[String]): Unit = {
+    Lambda.process()
+  }
+}

--- a/src/main/scala/com/gu/liveappversions/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/Lambda.scala
@@ -28,8 +28,8 @@ object AppStoreConnectApi {
     latestBetaWithExternalTesters.flatMap(betaBuild => buildsResponse.data.find(_.id == betaBuild.id))
   }
 
-  def latestBuildWithExternalTesters(token: String): Option[BuildDetails] = {
-    val buildsQuery = "/builds?limit=20&sort=-version&include=buildBetaDetail&filter[app]=409128287"
+  def latestBuildWithExternalTesters(token: String, appStoreConnectConfig: AppStoreConnectConfig): Option[BuildDetails] = {
+    val buildsQuery = s"/builds?limit=20&sort=-version&include=buildBetaDetail&filter[app]=${appStoreConnectConfig.appleAppId}"
     val request = new Request.Builder()
       .url(s"$appStoreConnectBaseUrl$buildsQuery")
       .addHeader("Authorization", s"Bearer $token")
@@ -54,8 +54,9 @@ object Lambda {
   }
 
   def process(): Unit = {
-    val token = JwtTokenBuilder.buildToken(AppStoreConnectConfig())
-    val latestBuild = AppStoreConnectApi.latestBuildWithExternalTesters(token)
+    val appStoreConnectConfig = AppStoreConnectConfig()
+    val token = JwtTokenBuilder.buildToken(appStoreConnectConfig)
+    val latestBuild = AppStoreConnectApi.latestBuildWithExternalTesters(token, appStoreConnectConfig)
     println(latestBuild)
   }
 


### PR DESCRIPTION
* Adds functionality for creating tokens to authenticate with App Store Connect API - borrowed from @NathanielBennett's implementation here: https://github.com/guardian/ophan-data-lake/blob/master/data-lake-lambdas/mobile-ingestion/src/main/scala/com/gu/itunes/jwt/JwtTokenBuilder.scala
* Adds logic for finding the latest version which has been released to external testers - this is essentially a Scala implementation of https://deliveroo.engineering/2019/12/10/testflight-app-store-connect-api.html (I've re-written this because Ruby is not well-supported by our tooling and most engineers here - myself included - will feel more confident maintaining a Scala project).
* Todo: unit tests, error handling, monitoring/alerts, writing to persistent storage, infrastructure as code, riff-raff config (I'm trying to keep each PR small and friendly for reviewers)