### PR TITLE
Deploy lambda to AWS using RiffRaff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ val circeVersion = "0.12.3"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "com.gu" %% "simple-configuration-ssm" % "1.4.1",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.8.2",
   "com.pauldijou" %% "jwt-core" % "4.2.0",
   "com.squareup.okhttp3" % "okhttp" % "4.3.1",

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,7 @@ enablePlugins(RiffRaffArtifact)
 
 assemblyJarName := s"${name.value}.jar"
 assemblyMergeStrategy in assembly := {
-  case "META-INF/MANIFEST.MF" => MergeStrategy.discard
-  case "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat" => MergeStrategy.last
+  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,14 @@ libraryDependencies ++= Seq(
 enablePlugins(RiffRaffArtifact)
 
 assemblyJarName := s"${name.value}.jar"
+assemblyMergeStrategy in assembly := {
+  case "META-INF/MANIFEST.MF" => MergeStrategy.discard
+  case "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat" => MergeStrategy.last
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
+
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -75,7 +75,7 @@ Resources:
           APPLE_APP_ID: !Ref AppleAppId
       Description: Lambda function which retrieves the latest beta version from App Store Connect.
       Handler: com.gu.liveappversions.Lambda::handler
-      MemorySize: 128
+      MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -16,6 +16,9 @@ Parameters:
       - CODE
       - PROD
     Default: CODE
+  AppleAppId:
+    Description: The Apple id of the iOS app which will be polled against
+    Type: String
   DeployBucket:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
@@ -62,6 +65,7 @@ Resources:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
+          APPLE_APP_ID: !Ref AppleAppId
       Description: Lambda function which retrieves the latest beta version from App Store Connect.
       Handler: com.gu.liveappversions.Lambda::handler
       MemorySize: 128

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -72,6 +72,7 @@ Resources:
   DailyEvent:
     Type: AWS::Events::Rule
     Properties:
+      State: DISABLED
       Description: Event sent to process the previous day of data
       ScheduleExpression: cron(14 3 * * ? *)
       Targets:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -73,8 +73,8 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       State: DISABLED
-      Description: Event sent to process the previous day of data
-      ScheduleExpression: cron(14 3 * * ? *)
+      Description: Triggers the lambda periodically, allowing us to check whether a new version has been released
+      ScheduleExpression: rate(5 minutes)
       Targets:
         - Id: Lambda
           Arn: !GetAtt Lambda.Arn

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -52,6 +52,13 @@ Resources:
               Action:
                 - lambda:InvokeFunction
               Resource: "*"
+        - PolicyName: lambda
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+              Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Stage}/${Stack}/${App}
   Lambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -1,0 +1,87 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Lambda function which retrieves the latest beta version from App Store Connect.
+Parameters:
+  Stack:
+    Description: Stack name
+    Type: String
+    Default: mobile
+  App:
+    Description: Application name
+    Type: String
+    Default: live-app-versions
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - CODE
+      - PROD
+    Default: CODE
+  DeployBucket:
+    Description: Bucket where RiffRaff uploads artifacts on deploy
+    Type: String
+    Default: mobile-dist
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: logs
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+              Resource: arn:aws:logs:*:*:*
+        - PolicyName: lambda
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - lambda:InvokeFunction
+              Resource: "*"
+  Lambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub ${App}-${Stage}
+      Code:
+        S3Bucket:
+          Ref: DeployBucket
+        S3Key: !Sub ${Stack}/${Stage}/${App}/${App}.jar
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Stack: !Ref Stack
+          App: !Ref App
+      Description: Lambda function which retrieves the latest beta version from App Store Connect.
+      Handler: com.gu.liveappversions.Lambda::handler
+      MemorySize: 128
+      Role: !GetAtt ExecutionRole.Arn
+      Runtime: java8
+      Timeout: 60
+
+  DailyEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Event sent to process the previous day of data
+      ScheduleExpression: cron(14 3 * * ? *)
+      Targets:
+        - Id: Lambda
+          Arn: !GetAtt Lambda.Arn
+
+  DailyEventLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt Lambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DailyEvent.Arn

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -80,7 +80,7 @@ Resources:
       Runtime: java8
       Timeout: 60
 
-  DailyEvent:
+  PollingEvent:
     Type: AWS::Events::Rule
     Properties:
       State: DISABLED
@@ -90,10 +90,10 @@ Resources:
         - Id: Lambda
           Arn: !GetAtt Lambda.Arn
 
-  DailyEventLambdaPermission:
+  PollingEventLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt Lambda.Arn
       Principal: events.amazonaws.com
-      SourceArn: !GetAtt DailyEvent.Arn
+      SourceArn: !GetAtt PollingEvent.Arn

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -52,7 +52,7 @@ Resources:
               Action:
                 - lambda:InvokeFunction
               Resource: "*"
-        - PolicyName: lambda
+        - PolicyName: privateConfiguration
           PolicyDocument:
             Statement:
               Effect: Allow

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,19 @@
+stacks: [mobile]
+regions: [eu-west-1]
+
+deployments:
+  live-app-versions:
+    type: aws-lambda
+    parameters:
+      bucket: mobile-dist
+      functionNames: [live-app-versions-]
+      fileName: live-app-versions.jar
+      prefixStack: false
+    dependencies: [live-app-versions-cfn]
+  live-app-versions-cfn:
+    type: cloud-formation
+    app: live-app-versions
+    parameters:
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: live-app-versions
+      templatePath: cfn.yaml

--- a/src/main/scala/com/gu/liveappversions/AccessToken.scala
+++ b/src/main/scala/com/gu/liveappversions/AccessToken.scala
@@ -12,7 +12,7 @@ object JwtTokenBuilder {
     val header = new JwtHeader(
       algorithm = Some(JwtAlgorithm.ES256),
       typ = Some("typ"),
-      keyId = Some(appStoreConnectConfig.privateKeyId),
+      keyId = Some(appStoreConnectConfig.keyId),
       contentType = Some("application/json"))
     val claim = JwtClaim(
       issuer = Some(appStoreConnectConfig.issuerId),

--- a/src/main/scala/com/gu/liveappversions/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/Lambda.scala
@@ -50,20 +50,14 @@ object Lambda {
   def handler(context: Context): Unit = {
     val env = Env()
     logger.info(s"Starting $env")
-    process()
+    process(env)
   }
 
-  def process(): Unit = {
-    val appStoreConnectConfig = AppStoreConnectConfig()
+  def process(env: Env): Unit = {
+    val appStoreConnectConfig = AppStoreConnectConfig(env)
     val token = JwtTokenBuilder.buildToken(appStoreConnectConfig)
     val latestBuild = AppStoreConnectApi.latestBuildWithExternalTesters(token, appStoreConnectConfig)
     println(latestBuild)
   }
 
-}
-
-object TestIt {
-  def main(args: Array[String]): Unit = {
-    Lambda.process()
-  }
 }

--- a/src/test/scala/com.gu.liveappversions.integration/IntegrationTest.scala
+++ b/src/test/scala/com.gu.liveappversions.integration/IntegrationTest.scala
@@ -1,0 +1,12 @@
+package com.gu.liveappversions.integration
+
+import com.gu.liveappversions.Config.Env
+import com.gu.liveappversions.Lambda
+
+object IntegrationTest {
+
+  def main(args: Array[String]): Unit = {
+    Lambda.process(Env())
+  }
+
+}


### PR DESCRIPTION
* Sets up the infrastructure 
* Makes the project deployable using RiffRaff
* Reads private credentials from parameter store (instead of environment variables)
* Moves the local runner to `src/test` (to keep the main application code tidy)