### PR TITLE
Upload latest build information to S3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ val circeVersion = "0.12.3"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.714",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.1", // Pin a more recent version to avoid Snyk vulnerabilities introduced by s3 sdk
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
   "com.gu" %% "simple-configuration-ssm" % "1.4.1",

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ enablePlugins(RiffRaffArtifact)
 assemblyJarName := s"${name.value}.jar"
 assemblyMergeStrategy in assembly := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+  case "module-info.class" => MergeStrategy.discard //See: https://stackoverflow.com/a/55557287
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,8 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
-  "org.slf4j" % "slf4j-api" % "1.7.30"
+  "org.slf4j" % "slf4j-api" % "1.7.30",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ scalacOptions ++= Seq(
 val circeVersion = "0.12.3"
 
 libraryDependencies ++= Seq(
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.714",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
   "com.gu" %% "simple-configuration-ssm" % "1.4.1",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -23,6 +23,12 @@ Parameters:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
     Default: mobile-dist
+Mappings:
+  StageVariables:
+    CODE:
+      UploadPath: reserved-paths/CODE/ios-live-app/
+    PROD:
+     UploadPath: reserved-paths/ios-live-app/
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -59,6 +65,16 @@ Resources:
               Action:
                 - ssm:GetParametersByPath
               Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Stage}/${Stack}/${App}
+        - PolicyName: uploadBuildOutputToS3
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - s3:PutObject
+              Resource: !Sub
+                - arn:aws:s3:::static-content-dist/${Path}/*
+                - Path: !FindInMap [StageVariables, !Ref Stage, UploadPath]
+
   Lambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -72,7 +72,7 @@ Resources:
               Action:
                 - s3:PutObject
               Resource: !Sub
-                - arn:aws:s3:::static-content-dist/${Path}/*
+                - arn:aws:s3:::static-content-dist/${Path}*
                 - Path: !FindInMap [StageVariables, !Ref Stage, UploadPath]
 
   Lambda:

--- a/src/main/scala/com/gu/liveappversions/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/liveappversions/AppStoreConnectApi.scala
@@ -1,0 +1,34 @@
+package com.gu.liveappversions
+
+import com.gu.liveappversions.Config.AppStoreConnectConfig
+import okhttp3.{ OkHttpClient, Request }
+import io.circe.parser._
+import io.circe.generic.auto._
+
+import scala.util.Try
+
+object AppStoreConnectApi {
+
+  case class BuildAttributes(version: String)
+  case class BuildDetails(id: String, attributes: BuildAttributes)
+  case class BetaBuildAttributes(externalBuildState: String)
+  case class BetaBuildDetails(id: String, attributes: BetaBuildAttributes)
+
+  case class BuildsResponse(data: List[BuildDetails], included: List[BetaBuildDetails])
+
+  val client = new OkHttpClient
+  val appStoreConnectBaseUrl = "https://api.appstoreconnect.apple.com/v1"
+
+  def getLatestBetaBuilds(token: String, appStoreConnectConfig: AppStoreConnectConfig): Try[BuildsResponse] = {
+    val buildsQuery = s"/builds?limit=20&sort=-version&include=buildBetaDetail&filter[app]=${appStoreConnectConfig.appleAppId}"
+    val request = new Request.Builder()
+      .url(s"$appStoreConnectBaseUrl$buildsQuery")
+      .addHeader("Authorization", s"Bearer $token")
+      .build
+    for {
+      httpResponse <- Try(client.newCall(request).execute)
+      buildsResponse <- decode[BuildsResponse](httpResponse.body().string()).toTry
+    } yield buildsResponse
+  }
+
+}

--- a/src/main/scala/com/gu/liveappversions/Aws.scala
+++ b/src/main/scala/com/gu/liveappversions/Aws.scala
@@ -1,0 +1,16 @@
+package com.gu.liveappversions
+
+import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.regions.Regions
+
+object Aws {
+
+  val euWest = Regions.EU_WEST_1
+
+  val credentials = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider("mobile"), // Used when running locally
+    new EnvironmentVariableCredentialsProvider() // Used by AWS lambda
+  )
+
+}

--- a/src/main/scala/com/gu/liveappversions/Aws.scala
+++ b/src/main/scala/com/gu/liveappversions/Aws.scala
@@ -1,15 +1,15 @@
 package com.gu.liveappversions
 
-import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider}
+import com.amazonaws.auth.{ AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider }
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions
 
 object Aws {
 
-  val euWest = Regions.EU_WEST_1
+  val euWest1 = Regions.EU_WEST_1
 
-  val credentials = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("mobile"), // Used when running locally
+  def credentials(profileName: String) = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider(profileName), // Used when running locally
     new EnvironmentVariableCredentialsProvider() // Used by AWS lambda
   )
 

--- a/src/main/scala/com/gu/liveappversions/BuildOutput.scala
+++ b/src/main/scala/com/gu/liveappversions/BuildOutput.scala
@@ -28,7 +28,7 @@ object BuildOutput {
     }
   }
 
-  def findLatestBuildWithExternalTesters(buildsResponse: BuildsResponse): Try[BuildOutput] = {
+  def findLatestBuildsWithExternalTesters(buildsResponse: BuildsResponse): Try[BuildOutput] = {
     val betasWithExternalTesters = buildsResponse.included.filter(_.attributes.externalBuildState == "IN_BETA_TESTING")
     for {
       latestBetaWithExternalTesters <- Try { buildAttributesForBuildDetails(betasWithExternalTesters.head.id, buildsResponse.data).get }
@@ -37,7 +37,7 @@ object BuildOutput {
   }
 
   def fromAppStoreConnectResponse(buildsResponse: BuildsResponse): Try[BuildOutput] = {
-    findLatestBuildWithExternalTesters(buildsResponse)
+    findLatestBuildsWithExternalTesters(buildsResponse)
   }
 
 }

--- a/src/main/scala/com/gu/liveappversions/BuildOutput.scala
+++ b/src/main/scala/com/gu/liveappversions/BuildOutput.scala
@@ -1,0 +1,43 @@
+package com.gu.liveappversions
+
+import com.gu.liveappversions.AppStoreConnectApi.{ BetaBuildDetails, BuildAttributes, BuildDetails, BuildsResponse }
+import io.circe.Encoder
+import io.circe.generic.auto._
+import io.circe.generic.semiauto._
+
+import scala.util.{ Failure, Success, Try }
+
+case class BuildOutput(latestReleasedBuild: BuildAttributes, previouslyReleasedBuilds: List[BuildAttributes])
+
+object BuildOutput {
+
+  implicit val buildOutputEncoder: Encoder[BuildOutput] = deriveEncoder[BuildOutput]
+
+  def buildAttributesForBuildDetails(buildId: String, buildsDetails: List[BuildDetails]): Option[BuildAttributes] = {
+    buildsDetails.find(_.id == buildId).map(_.attributes)
+  }
+
+  def findPreviousThreeBetaVersions(allBetas: List[BetaBuildDetails], buildsDetails: List[BuildDetails]): Try[List[BuildAttributes]] = {
+    val attemptToFindPreviousThreeBetas = allBetas.slice(1, 4).flatMap { beta =>
+      buildAttributesForBuildDetails(beta.id, buildsDetails)
+    }
+    if (attemptToFindPreviousThreeBetas.size != 3) {
+      Failure(new RuntimeException(s"Expected to find at least three previous betas but found ${attemptToFindPreviousThreeBetas.size}"))
+    } else {
+      Success(attemptToFindPreviousThreeBetas)
+    }
+  }
+
+  def findLatestBuildWithExternalTesters(buildsResponse: BuildsResponse): Try[BuildOutput] = {
+    val betasWithExternalTesters = buildsResponse.included.filter(_.attributes.externalBuildState == "IN_BETA_TESTING")
+    for {
+      latestBetaWithExternalTesters <- Try { buildAttributesForBuildDetails(betasWithExternalTesters.head.id, buildsResponse.data).get }
+      previousBetasWithExternalTesters <- findPreviousThreeBetaVersions(betasWithExternalTesters, buildsResponse.data)
+    } yield BuildOutput(latestBetaWithExternalTesters, previousBetasWithExternalTesters)
+  }
+
+  def fromAppStoreConnectResponse(buildsResponse: BuildsResponse): Try[BuildOutput] = {
+    findLatestBuildWithExternalTesters(buildsResponse)
+  }
+
+}

--- a/src/main/scala/com/gu/liveappversions/BuildOutput.scala
+++ b/src/main/scala/com/gu/liveappversions/BuildOutput.scala
@@ -1,6 +1,7 @@
 package com.gu.liveappversions
 
 import com.gu.liveappversions.AppStoreConnectApi.{ BetaBuildDetails, BuildAttributes, BuildDetails, BuildsResponse }
+import com.gu.liveappversions.Lambda.logger
 import io.circe.Encoder
 import io.circe.generic.auto._
 import io.circe.generic.semiauto._
@@ -33,7 +34,10 @@ object BuildOutput {
     for {
       latestBetaWithExternalTesters <- Try { buildAttributesForBuildDetails(betasWithExternalTesters.head.id, buildsResponse.data).get }
       previousBetasWithExternalTesters <- findPreviousThreeBetaVersions(betasWithExternalTesters, buildsResponse.data)
-    } yield BuildOutput(latestBetaWithExternalTesters, previousBetasWithExternalTesters)
+    } yield {
+      logger.info(s"The latest iOS beta with external beta testers is: ${latestBetaWithExternalTesters}. Previous versions are: ${previousBetasWithExternalTesters}")
+      BuildOutput(latestBetaWithExternalTesters, previousBetasWithExternalTesters)
+    }
   }
 
   def fromAppStoreConnectResponse(buildsResponse: BuildsResponse): Try[BuildOutput] = {

--- a/src/main/scala/com/gu/liveappversions/Config.scala
+++ b/src/main/scala/com/gu/liveappversions/Config.scala
@@ -29,10 +29,9 @@ object Config {
         app = env.app,
         stack = env.stack,
         stage = env.stage,
-        region = Aws.euWest.getName
-      )
+        region = Aws.euWest1.getName)
 
-      val ssmPrivateConfig = ConfigurationLoader.load(setupAppIdentity(env), Aws.credentials) {
+      val ssmPrivateConfig = ConfigurationLoader.load(setupAppIdentity(env), Aws.credentials("mobile")) {
         case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
       }
 

--- a/src/main/scala/com/gu/liveappversions/Config.scala
+++ b/src/main/scala/com/gu/liveappversions/Config.scala
@@ -1,7 +1,5 @@
 package com.gu.liveappversions
 
-import com.amazonaws.auth.{ AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider }
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.turo.pushy.apns.auth.ApnsSigningKey
 import com.gu.AwsIdentity
 import com.gu.conf.{ ConfigurationLoader, SSMConfigurationLocation }
@@ -31,14 +29,10 @@ object Config {
         app = env.app,
         stack = env.stack,
         stage = env.stage,
-        region = "eu-west-1")
-
-      val awsCredentials = new AWSCredentialsProviderChain(
-        new ProfileCredentialsProvider("mobile"), // Used when running locally
-        new EnvironmentVariableCredentialsProvider() // Used by AWS lambda
+        region = Aws.euWest.getName
       )
 
-      val ssmPrivateConfig = ConfigurationLoader.load(setupAppIdentity(env), awsCredentials) {
+      val ssmPrivateConfig = ConfigurationLoader.load(setupAppIdentity(env), Aws.credentials) {
         case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
       }
 

--- a/src/main/scala/com/gu/liveappversions/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/Lambda.scala
@@ -27,7 +27,7 @@ object Lambda {
       case Success(buildOutput) =>
         logger.info(s"The latest iOS beta with external beta testers is: ${buildOutput.latestReleasedBuild}. Previous versions are: ${buildOutput.previouslyReleasedBuilds}")
         S3Uploader.attemptUpload(buildOutput, env, uploadBucketName)
-      case Failure(ex) => logger.error("Failed to retrieve the latest build information from App Store Connect...")
+      case Failure(ex) => logger.error(s"Failed to retrieve the latest build information from App Store Connect due to: $ex")
     }
 
   }

--- a/src/main/scala/com/gu/liveappversions/S3Uploader.scala
+++ b/src/main/scala/com/gu/liveappversions/S3Uploader.scala
@@ -19,7 +19,7 @@ object S3Uploader {
 
   def attemptUpload(buildOutput: BuildOutput, env: Env, bucketName: String): Try[PutObjectResult] = {
 
-    val stagePrefix = if (env.stage == "PROD") { "/" } else { s"/${env.stage}/" }
+    val stagePrefix = if (env.stage == "PROD") "/" else s"/${env.stage}/"
     val fileObjectKeyName = s"reserved-paths${stagePrefix}ios-live-app/recent-beta-releases.json"
     val buildAttributesStream: ByteArrayInputStream = new ByteArrayInputStream(buildOutput.asJson.toString().getBytes)
 

--- a/src/main/scala/com/gu/liveappversions/S3Uploader.scala
+++ b/src/main/scala/com/gu/liveappversions/S3Uploader.scala
@@ -1,11 +1,49 @@
 package com.gu.liveappversions
 
+import java.io.ByteArrayInputStream
+
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.{ CannedAccessControlList, ObjectMetadata, PutObjectRequest }
+import com.gu.liveappversions.Config.Env
+import com.gu.liveappversions.Lambda.logger
+import io.circe.syntax._
+
+import scala.util.{ Failure, Success, Try }
 
 object S3Uploader {
 
-  val s3Client = AmazonS3ClientBuilder.standard()
-    .withRegion(Aws.euWest.getName)
-    .build();
+  private val s3Client = AmazonS3ClientBuilder.standard()
+    .withCredentials(Aws.credentials("developerPlayground"))
+    .withRegion(Aws.euWest1.getName)
+    .build()
+
+  def attemptUpload(buildOutput: BuildOutput, env: Env, bucketName: String): Unit = {
+
+    val stagePrefix = if (env.stage == "PROD") { "/" } else { s"/${env.stage}/" }
+    val fileObjectKeyName = s"reserved-paths${stagePrefix}ios-live-app/recent-beta-releases.json"
+    val buildAttributesStream: ByteArrayInputStream = new ByteArrayInputStream(buildOutput.asJson.toString().getBytes)
+
+    val metadata = new ObjectMetadata()
+    metadata.setContentType("application/json")
+    metadata.setCacheControl("max-age=60")
+
+    val accessControl = if (env.stage == "PROD") {
+      CannedAccessControlList.PublicRead
+    } else {
+      CannedAccessControlList.Private //It's preferable to avoid serving test files via https://mobile.guardianapis.com/
+    }
+
+    val putObjectRequest = new PutObjectRequest(bucketName, fileObjectKeyName, buildAttributesStream, metadata)
+      .withCannedAcl(accessControl)
+
+    Try(s3Client.putObject(putObjectRequest)) match {
+      case Success(_) =>
+        logger.info(s"Successfully uploaded new build info to S3 (bucket: $bucketName | keyName: $fileObjectKeyName)")
+      case Failure(exception) =>
+        logger.error(s"Failed to uploaded build to S3 (bucket: $bucketName | keyName: $fileObjectKeyName) due to: $exception")
+        throw exception
+    }
+
+  }
 
 }

--- a/src/main/scala/com/gu/liveappversions/S3Uploader.scala
+++ b/src/main/scala/com/gu/liveappversions/S3Uploader.scala
@@ -1,0 +1,11 @@
+package com.gu.liveappversions
+
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+
+object S3Uploader {
+
+  val s3Client = AmazonS3ClientBuilder.standard()
+    .withRegion(Aws.euWest.getName)
+    .build();
+
+}

--- a/src/test/scala/com.gu.liveappversions.integration/IntegrationTest.scala
+++ b/src/test/scala/com.gu.liveappversions.integration/IntegrationTest.scala
@@ -6,7 +6,7 @@ import com.gu.liveappversions.Lambda
 object IntegrationTest {
 
   def main(args: Array[String]): Unit = {
-    Lambda.process(Env())
+    Lambda.process(Env(), "jacob-w-test") // This bucket lives in the Developer Playground account (to avoid polluting Mobile)
   }
 
 }

--- a/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
+++ b/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
@@ -1,0 +1,103 @@
+package com.gu.liveappversions
+
+import com.gu.liveappversions.AppStoreConnectApi.{BetaBuildAttributes, BetaBuildDetails, BuildAttributes, BuildDetails, BuildsResponse}
+import org.scalatest.FunSuite
+
+class BuildOutputTest extends FunSuite {
+
+  val releasedToExternalBetaDetails = BetaBuildDetails("id123", BetaBuildAttributes("IN_BETA_TESTING"))
+  val releasedToExternalBuildDetails = BuildDetails("id123", BuildAttributes("8.16 (5)"))
+
+  val unreleasedToExternalBetaDetails = BetaBuildDetails("id999", BetaBuildAttributes("IN_REVIEW"))
+  val unreleasedToExternalBuildDetails = BuildDetails("id999", BuildAttributes("8.16 (56)"))
+
+  test("findLatestBuildsWithExternalTesters should correctly identify the 4 most recent beta versions from Apple's response") {
+    val buildDetails = List(
+      releasedToExternalBuildDetails,
+      releasedToExternalBuildDetails.copy(id = "id124").copy(attributes = BuildAttributes("8.16 (4)")),
+      releasedToExternalBuildDetails.copy(id = "id125").copy(attributes = BuildAttributes("8.16 (3)")),
+      releasedToExternalBuildDetails.copy(id = "id126").copy(attributes = BuildAttributes("8.16 (2)")),
+      releasedToExternalBuildDetails.copy(id = "id127").copy(attributes = BuildAttributes("8.16 (1)"))
+    )
+    val betaDetails = List(
+      releasedToExternalBetaDetails,
+      releasedToExternalBetaDetails.copy(id = "id124"),
+      releasedToExternalBetaDetails.copy(id = "id125"),
+      releasedToExternalBetaDetails.copy(id = "id126"),
+      releasedToExternalBetaDetails.copy(id = "id127")
+    )
+    val buildsResponse = BuildsResponse(buildDetails, betaDetails)
+    val result = BuildOutput.findLatestBuildsWithExternalTesters(buildsResponse)
+
+    assert(result.get.latestReleasedBuild.version === "8.16 (5)")
+    assert(result.get.previouslyReleasedBuilds.map(_.version) === List("8.16 (4)", "8.16 (3)", "8.16 (2)"))
+
+  }
+
+  test("findLatestBuildsWithExternalTesters should ignore betas which have NOT been released to external testers") {
+    val buildDetails = List(
+      unreleasedToExternalBuildDetails,
+      releasedToExternalBuildDetails,
+      releasedToExternalBuildDetails.copy(id = "id124").copy(attributes = BuildAttributes("8.16 (4)")),
+      releasedToExternalBuildDetails.copy(id = "id125").copy(attributes = BuildAttributes("8.16 (3)")),
+      releasedToExternalBuildDetails.copy(id = "id126").copy(attributes = BuildAttributes("8.16 (2)")),
+    )
+    val betaDetails = List(
+      unreleasedToExternalBetaDetails,
+      releasedToExternalBetaDetails,
+      releasedToExternalBetaDetails.copy(id = "id124"),
+      releasedToExternalBetaDetails.copy(id = "id125"),
+      releasedToExternalBetaDetails.copy(id = "id126")
+    )
+    val buildsResponse = BuildsResponse(buildDetails, betaDetails)
+    val result = BuildOutput.findLatestBuildsWithExternalTesters(buildsResponse)
+
+    assert(result.get.latestReleasedBuild.version === "8.16 (5)")
+    assert(result.get.previouslyReleasedBuilds.map(_.version) === List("8.16 (4)", "8.16 (3)", "8.16 (2)"))
+
+  }
+
+  test("findLatestBuildsWithExternalTesters should fail if there are less than 4 recent beta versions") {
+    val buildDetails = List(releasedToExternalBuildDetails, releasedToExternalBuildDetails, releasedToExternalBuildDetails)
+    val betaDetails = List(releasedToExternalBetaDetails, releasedToExternalBetaDetails, releasedToExternalBetaDetails)
+    val buildsResponse = BuildsResponse(buildDetails, betaDetails)
+    val result = BuildOutput.findLatestBuildsWithExternalTesters(buildsResponse)
+    assert(result.isFailure)
+  }
+
+  test("findLatestBuildsWithExternalTesters should fail if it cannot find the version name for the most recent beta") {
+    val buildDetails = List(
+      releasedToExternalBuildDetails.copy("fakeId"),
+      releasedToExternalBuildDetails.copy(id = "id124").copy(attributes = BuildAttributes("8.16 (4)")),
+      releasedToExternalBuildDetails.copy(id = "id125").copy(attributes = BuildAttributes("8.16 (3)")),
+      releasedToExternalBuildDetails.copy(id = "id126").copy(attributes = BuildAttributes("8.16 (2)")),
+    )
+    val betaDetails = List(
+      releasedToExternalBetaDetails,
+      releasedToExternalBetaDetails.copy(id = "id124"),
+      releasedToExternalBetaDetails.copy(id = "id125"),
+      releasedToExternalBetaDetails.copy(id = "id126")
+    )
+    val buildsResponse = BuildsResponse(buildDetails, betaDetails)
+    val result = BuildOutput.findLatestBuildsWithExternalTesters(buildsResponse)
+    assert(result.isFailure)
+  }
+
+  test("findPreviousThreeBetaVersions should fail if it finds less than 3 previous versions (due to mismatched ids)") {
+    val allBetas = List(
+      releasedToExternalBetaDetails,
+      releasedToExternalBetaDetails.copy(id = "id124"),
+      releasedToExternalBetaDetails.copy(id = "id125"),
+      releasedToExternalBetaDetails.copy(id = "id126")
+    )
+    val buildDetails = List(
+      releasedToExternalBuildDetails,
+      releasedToExternalBuildDetails.copy(id = "id127"),
+      releasedToExternalBuildDetails.copy(id = "id128"),
+      releasedToExternalBuildDetails.copy(id = "id129"),
+    )
+    val result = BuildOutput.findPreviousThreeBetaVersions(allBetas, buildDetails)
+    assert(result.isFailure)
+  }
+
+}


### PR DESCRIPTION
* Adds code for uploading JSON files to S3
* Adds IAM permissions to allow the lambda to upload to S3
* Surfaces information about the last few builds (instead of just the most recent one) because [some clients](https://github.com/guardian/data-lake-alerts) will need this history.
* Adds unit tests for the main logic
* Some minor refactoring
