### PR TITLE
Add alert for consistent failures

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -97,3 +97,27 @@ Resources:
       FunctionName: !GetAtt Lambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt PollingEvent.Arn
+
+  FailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
+      AlarmName: !Sub Failures when retrieving/storing latest iOS beta version in ${Stage}
+      AlarmDescription: |
+        Tips for debugging this alert:
+        * Check the logs at https://logs.gutools.co.uk/s/mobile/goto/0538f002572d0d01f37e4f0b9212dc3a
+        * Check App Store Connect API status at: https://developer.apple.com/system-status/
+        * View the source code at https://github.com/guardian/live-app-versions
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref Lambda
+      Period: 600
+      EvaluationPeriods: 6
+      DatapointsToAlarm: 6
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching


### PR DESCRIPTION
This lambda will [throw an exception](https://github.com/guardian/live-app-versions/blob/master/src/main/scala/com/gu/liveappversions/Lambda.scala#L32) if it fails to update the JSON file stored in S3. 

Individual failures should be tolerated, since the lambda makes a HTTP request to the App Store Connect API and this may occasionally fail. The impact of an individual failure is minor: we will serve stale data for slightly longer than normal. Once the [schedule](https://github.com/guardian/live-app-versions/blob/master/cfn.yaml#L88) is enabled, temporary problems should resolve themselves without human intervention. 

Consequently this alert should only fire if there are consistent failures (as these may indicate long-term or permanent problems - e.g. revoked API key or bug in our codebase - which require human intervention).