### PR TITLE
Allow lambda to make object public

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -71,6 +71,7 @@ Resources:
               Effect: Allow
               Action:
                 - s3:PutObject
+                - s3:PutObjectAcl
               Resource: !Sub
                 - arn:aws:s3:::static-content-dist/${Path}*
                 - Path: !FindInMap [StageVariables, !Ref Stage, UploadPath]


### PR DESCRIPTION
This additional permission is required in order to make objects public. I didn't notice this whilst testing because this piece of functionality is [specific to the PROD lambda](https://github.com/guardian/live-app-versions/blob/master/src/main/scala/com/gu/liveappversions/S3Uploader.scala#L30-L31).