### PR TITLE
Enable polling schedule in production

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -27,8 +27,10 @@ Mappings:
   StageVariables:
     CODE:
       UploadPath: reserved-paths/CODE/ios-live-app/
+      ScheduleStatus: DISABLED
     PROD:
      UploadPath: reserved-paths/ios-live-app/
+     ScheduleStatus: ENABLED
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -99,7 +101,7 @@ Resources:
   PollingEvent:
     Type: AWS::Events::Rule
     Properties:
-      State: DISABLED
+      State: !FindInMap [StageVariables, !Ref Stage, ScheduleStatus]
       Description: Triggers the lambda periodically, allowing us to check whether a new version has been released
       ScheduleExpression: rate(5 minutes)
       Targets:


### PR DESCRIPTION
Now that the major functionality is [working](https://mobile.guardianapis.com/static/reserved-paths/ios-live-app/recent-beta-releases.json), we should enable the CloudWatch event rule to ensure that the production data in S3 is kept up to date.