### PR TITLE
Update merge strategy to fix logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ enablePlugins(RiffRaffArtifact)
 
 assemblyJarName := s"${name.value}.jar"
 assemblyMergeStrategy in assembly := {
-  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+  case "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat" => MergeStrategy.first
+  case "META-INF/io.netty.versions.properties" => MergeStrategy.discard
   case "module-info.class" => MergeStrategy.discard //See: https://stackoverflow.com/a/55557287
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ enablePlugins(RiffRaffArtifact)
 
 assemblyJarName := s"${name.value}.jar"
 assemblyMergeStrategy in assembly := {
-  case "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat" => MergeStrategy.first
+  case "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat" => MergeStrategy.last
   case "META-INF/io.netty.versions.properties" => MergeStrategy.discard
   case "module-info.class" => MergeStrategy.discard //See: https://stackoverflow.com/a/55557287
   case x =>


### PR DESCRIPTION
This [commit](https://github.com/guardian/live-app-versions/pull/2/commits/b44959c3b91b153dd1bd2daf447e366767ad6522) was too aggressive 🙈 

It leads to the following error:
`ERROR StatusLogger Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...`

This PR introduces a more targetted merge strategy which allows us to keep `Log4j2Plugins.dat`, which is required.