### PR TITLE
Improve monitoring

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -146,7 +146,7 @@ Resources:
                   Value: !Ref Lambda
             Period: 3600
             Stat: Sum
-            ReturnData: false
+          ReturnData: false
         - Id: m2
           Label: Number of invocations for lambda
           MetricStat:
@@ -158,7 +158,7 @@ Resources:
                   Value: !Ref Lambda
             Period: 3600
             Stat: Sum
-            ReturnData: false
+          ReturnData: false
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
       Threshold: 100

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -28,9 +28,11 @@ Mappings:
     CODE:
       UploadPath: reserved-paths/CODE/ios-live-app/
       ScheduleStatus: DISABLED
+      AlarmActionsEnabled: FALSE
     PROD:
      UploadPath: reserved-paths/ios-live-app/
      ScheduleStatus: ENABLED
+     AlarmActionsEnabled: TRUE
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -120,6 +122,7 @@ Resources:
   FailureAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      ActionsEnabled: !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       AlarmName: !Sub Failures when retrieving/storing latest iOS beta version in ${Stage}
@@ -128,15 +131,34 @@ Resources:
         * Check the logs at https://logs.gutools.co.uk/s/mobile/goto/0538f002572d0d01f37e4f0b9212dc3a
         * Check App Store Connect API status at: https://developer.apple.com/system-status/
         * View the source code at https://github.com/guardian/live-app-versions
+      Metrics:
+        - Id: e1
+          Label: Error percentage of lambda
+          Expression: "100*(m1/m2)"
+        - Id: m1
+          Label: Number of errors for lambda
+          MetricStat:
+            Metric:
+              MetricName: Errors
+              Namespace: AWS/Lambda
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref Lambda
+            Period: 3600
+            Stat: Sum
+            ReturnData: false
+        - Id: m2
+          Label: Number of invocations for lambda
+          MetricStat:
+            Metric:
+              MetricName: Invocations
+              Namespace: AWS/Lambda
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref Lambda
+            Period: 3600
+            Stat: Sum
+            ReturnData: false
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref Lambda
-      Period: 600
-      EvaluationPeriods: 6
-      DatapointsToAlarm: 6
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: notBreaching
+      EvaluationPeriods: 1
+      Threshold: 100

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -30,9 +30,9 @@ Mappings:
       ScheduleStatus: DISABLED
       AlarmActionsEnabled: FALSE
     PROD:
-     UploadPath: reserved-paths/ios-live-app/
-     ScheduleStatus: ENABLED
-     AlarmActionsEnabled: TRUE
+      UploadPath: reserved-paths/ios-live-app/
+      ScheduleStatus: ENABLED
+      AlarmActionsEnabled: TRUE
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
The alert added in https://github.com/guardian/live-app-versions/pull/4 did not work as desired. Although it fired correctly in the first instance, it fired relatively frequently during the incident which was quite noisy and annoying. This seemed to happen because a handful of invocations were able to succeed; consequently the alert state kept changing between `OK` and `Alarm`.

This PR improves the alert by monitoring the % of failures for the lambda invocation. The alert will only fire if the error rate is 100% for one hour. If the service temporarily recovers, it will need to subsequently break entirely (for 1 hour) before the alarm fires again. I think that can probably be considered as a new incident, so it seems appropriate to me.

Here's an [example of that alert](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#alarmsV2:alarm/Failures+when+retrieving$2Fstoring+latest+iOS+beta+version+in+CODE) working in `CODE` (I intentionally broke the lambda at ~11:30, fixed it at ~13:20, and broke it again at ~13:30).