### PR TITLE
Restructure project to accommodate second lambda

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -101,7 +101,7 @@ Resources:
       Runtime: java8
       Timeout: 60
 
-  LiveAppVersionsLambda:
+  Lambda:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub live-app-versions-${Stage}
@@ -129,14 +129,14 @@ Resources:
       Description: Triggers the lambda periodically, allowing us to check whether a new version has been released
       ScheduleExpression: rate(5 minutes)
       Targets:
-        - Id: LiveAppVersionsLambda
-          Arn: !GetAtt LiveAppVersionsLambda.Arn
+        - Id: Lambda
+          Arn: !GetAtt Lambda.Arn
 
   PollingEventLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !GetAtt LiveAppVersionsLambda.Arn
+      FunctionName: !GetAtt Lambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt PollingEvent.Arn
 
@@ -164,7 +164,7 @@ Resources:
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref LiveAppVersionsLambda
+                  Value: !Ref Lambda
             Period: 3600
             Stat: Sum
           ReturnData: false
@@ -176,7 +176,7 @@ Resources:
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref LiveAppVersionsLambda
+                  Value: !Ref Lambda
             Period: 3600
             Stat: Sum
           ReturnData: false

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -80,7 +80,7 @@ Resources:
                 - arn:aws:s3:::static-content-dist/${Path}*
                 - Path: !FindInMap [StageVariables, !Ref Stage, UploadPath]
 
-  Lambda:
+  LiveAppVersionsLambda:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub ${App}-${Stage}
@@ -108,14 +108,14 @@ Resources:
       Description: Triggers the lambda periodically, allowing us to check whether a new version has been released
       ScheduleExpression: rate(5 minutes)
       Targets:
-        - Id: Lambda
-          Arn: !GetAtt Lambda.Arn
+        - Id: LiveAppVersionsLambda
+          Arn: !GetAtt LiveAppVersionsLambda.Arn
 
   PollingEventLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !GetAtt Lambda.Arn
+      FunctionName: !GetAtt LiveAppVersionsLambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt PollingEvent.Arn
 
@@ -143,7 +143,7 @@ Resources:
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref Lambda
+                  Value: !Ref LiveAppVersionsLambda
             Period: 3600
             Stat: Sum
           ReturnData: false
@@ -155,7 +155,7 @@ Resources:
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref Lambda
+                  Value: !Ref LiveAppVersionsLambda
             Period: 3600
             Stat: Sum
           ReturnData: false

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -80,6 +80,27 @@ Resources:
                 - arn:aws:s3:::static-content-dist/${Path}*
                 - Path: !FindInMap [StageVariables, !Ref Stage, UploadPath]
 
+  IosDeploymentsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub ${App}-${Stage}
+      Code:
+        S3Bucket:
+          Ref: DeployBucket
+        S3Key: !Sub ${Stack}/${Stage}/${App}/${App}.jar
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Stack: !Ref Stack
+          App: !Ref App
+          APPLE_APP_ID: !Ref AppleAppId
+      Description: Lambda function which distributes uploaded iOS builds to beta testers.
+      Handler: com.gu.iosdeployments.Lambda::handler
+      MemorySize: 1024
+      Role: !GetAtt ExecutionRole.Arn
+      Runtime: java8
+      Timeout: 60
+
   LiveAppVersionsLambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -83,7 +83,7 @@ Resources:
   IosDeploymentsLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ${App}-${Stage}
+      FunctionName: !Sub ios-deployments-${Stage}
       Code:
         S3Bucket:
           Ref: DeployBucket
@@ -104,7 +104,7 @@ Resources:
   LiveAppVersionsLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ${App}-${Stage}
+      FunctionName: !Sub live-app-versions-${Stage}
       Code:
         S3Bucket:
           Ref: DeployBucket

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     type: aws-lambda
     parameters:
       bucket: mobile-dist
-      functionNames: [live-app-versions-]
+      functionNames: [live-app-versions-, ios-deployments-]
       fileName: live-app-versions.jar
       prefixStack: false
     dependencies: [live-app-versions-cfn]

--- a/src/main/scala/com/gu/appstoreconnectapi/AccessToken.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AccessToken.scala
@@ -1,8 +1,8 @@
-package com.gu.liveappversions
+package com.gu.appstoreconnectapi
 
 import java.time.ZonedDateTime
 
-import com.gu.liveappversions.Config.AppStoreConnectConfig
+import com.gu.config.Config.AppStoreConnectConfig
 import pdi.jwt.{ Jwt, JwtAlgorithm, JwtClaim, JwtHeader }
 
 object JwtTokenBuilder {

--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -1,9 +1,10 @@
-package com.gu.liveappversions
+package com.gu.appstoreconnectapi
 
 import java.time.{ ZoneOffset, ZonedDateTime }
 
-import com.gu.liveappversions.Config.AppStoreConnectConfig
+import com.gu.config.Config.AppStoreConnectConfig
 import io.circe.Decoder.Result
+import io.circe.parser.decode
 import io.circe.{ Decoder, HCursor }
 import okhttp3.{ OkHttpClient, Request }
 import io.circe.parser._

--- a/src/main/scala/com/gu/config/Aws.scala
+++ b/src/main/scala/com/gu/config/Aws.scala
@@ -1,7 +1,7 @@
-package com.gu.liveappversions
+package com.gu.config
 
-import com.amazonaws.auth.{ AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider }
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{ AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider }
 import com.amazonaws.regions.Regions
 
 object Aws {

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -1,10 +1,11 @@
-package com.gu.liveappversions
+package com.gu.config
 
-import com.turo.pushy.apns.auth.ApnsSigningKey
-import com.gu.AwsIdentity
-import com.gu.conf.{ ConfigurationLoader, SSMConfigurationLocation }
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
+
+import com.gu.AwsIdentity
+import com.gu.conf.{ ConfigurationLoader, SSMConfigurationLocation }
+import com.turo.pushy.apns.auth.ApnsSigningKey
 
 object Config {
 

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -1,0 +1,21 @@
+package com.gu.iosdeployments
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.gu.config.Config.Env
+import org.slf4j.{ Logger, LoggerFactory }
+
+object Lambda {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def handler(context: Context): Unit = {
+    val env = Env()
+    logger.info(s"Starting $env")
+    process(env)
+  }
+
+  def process(env: Env): Unit = {
+    logger.info("Hello world")
+  }
+
+}

--- a/src/main/scala/com/gu/liveappversions/BuildOutput.scala
+++ b/src/main/scala/com/gu/liveappversions/BuildOutput.scala
@@ -1,6 +1,6 @@
 package com.gu.liveappversions
 
-import com.gu.liveappversions.AppStoreConnectApi.{ BetaBuildDetails, BuildAttributes, BuildDetails, BuildsResponse }
+import com.gu.appstoreconnectapi.AppStoreConnectApi.{ BetaBuildDetails, BuildAttributes, BuildDetails, BuildsResponse }
 import com.gu.liveappversions.Lambda.logger
 import io.circe.Encoder
 import io.circe.generic.auto._

--- a/src/main/scala/com/gu/liveappversions/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/Lambda.scala
@@ -1,10 +1,11 @@
 package com.gu.liveappversions
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.liveappversions.Config.{AppStoreConnectConfig, Env}
-import org.slf4j.{Logger, LoggerFactory}
+import com.gu.appstoreconnectapi.{ AppStoreConnectApi, JwtTokenBuilder }
+import com.gu.config.Config.{ AppStoreConnectConfig, Env }
+import org.slf4j.{ Logger, LoggerFactory }
 
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 object Lambda {
 

--- a/src/main/scala/com/gu/liveappversions/S3Uploader.scala
+++ b/src/main/scala/com/gu/liveappversions/S3Uploader.scala
@@ -4,7 +4,8 @@ import java.io.ByteArrayInputStream
 
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.{ CannedAccessControlList, ObjectMetadata, PutObjectRequest, PutObjectResult }
-import com.gu.liveappversions.Config.Env
+import com.gu.config.Aws
+import com.gu.config.Config.Env
 import com.gu.liveappversions.Lambda.logger
 import io.circe.syntax._
 

--- a/src/test/scala/com.gu.liveappversions.integration/IntegrationTest.scala
+++ b/src/test/scala/com.gu.liveappversions.integration/IntegrationTest.scala
@@ -1,6 +1,6 @@
 package com.gu.liveappversions.integration
 
-import com.gu.liveappversions.Config.Env
+import com.gu.config.Config.Env
 import com.gu.liveappversions.Lambda
 
 object IntegrationTest {

--- a/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
+++ b/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
@@ -2,7 +2,7 @@ package com.gu.liveappversions
 
 import java.time.ZonedDateTime
 
-import com.gu.liveappversions.AppStoreConnectApi.{BetaBuildAttributes, BetaBuildDetails, BuildAttributes, BuildDetails, BuildsResponse}
+import com.gu.appstoreconnectapi.AppStoreConnectApi.{BetaBuildAttributes, BetaBuildDetails, BuildAttributes, BuildDetails, BuildsResponse}
 import org.scalatest.FunSuite
 
 class BuildOutputTest extends FunSuite {


### PR DESCRIPTION
I need another lambda which accesses the App Store Connect API. This lambda will be used to automatically distribute builds to external testers (since moving away from TeamCity the iOS Team are having to doing this manually).

Since this project already has most of the code I need, I've restructured it to accommodate a second lambda. I've also added a basic "hello world" lambda just to prove that this all works as expected.

I've tested that the original lambda can still run successfully.

