### PR TITLE
Add read-only logic for iOS deployment functionality

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -2,11 +2,13 @@ package com.gu.appstoreconnectapi
 
 import java.time.{ ZoneOffset, ZonedDateTime }
 
+import com.gu.appstoreconnectapi.Conversion.{ LiveAppBeta, combineModels }
 import com.gu.config.Config.AppStoreConnectConfig
+import com.gu.okhttp.SharedClient
 import io.circe.Decoder.Result
 import io.circe.parser.decode
 import io.circe.{ Decoder, HCursor }
-import okhttp3.{ OkHttpClient, Request }
+import okhttp3.Request
 import io.circe.parser._
 import io.circe.generic.auto._
 
@@ -25,24 +27,24 @@ object AppStoreConnectApi {
 
   case class BuildAttributes(version: String, uploadedDate: ZonedDateTime)
   case class BuildDetails(id: String, attributes: BuildAttributes)
-  case class BetaBuildAttributes(externalBuildState: String)
+  case class BetaBuildAttributes(internalBuildState: String, externalBuildState: String)
   case class BetaBuildDetails(id: String, attributes: BetaBuildAttributes)
-
   case class BuildsResponse(data: List[BuildDetails], included: List[BetaBuildDetails])
 
-  val client = new OkHttpClient
   val appStoreConnectBaseUrl = "https://api.appstoreconnect.apple.com/v1"
 
-  def getLatestBetaBuilds(token: String, appStoreConnectConfig: AppStoreConnectConfig): Try[BuildsResponse] = {
+  def getLatestBetaBuilds(token: String, appStoreConnectConfig: AppStoreConnectConfig): Try[List[LiveAppBeta]] = {
     val buildsQuery = s"/builds?limit=20&sort=-version&include=buildBetaDetail&filter[app]=${appStoreConnectConfig.appleAppId}"
     val request = new Request.Builder()
       .url(s"$appStoreConnectBaseUrl$buildsQuery")
       .addHeader("Authorization", s"Bearer $token")
       .build
     for {
-      httpResponse <- Try(client.newCall(request).execute)
-      buildsResponse <- decode[BuildsResponse](httpResponse.body().string()).toTry
-    } yield buildsResponse
+      httpResponse <- Try(SharedClient.client.newCall(request).execute)
+      bodyAsString <- SharedClient.getResponseBodyIfSuccessful("App Store Connect API", httpResponse)
+      buildsResponse <- decode[BuildsResponse](bodyAsString).toTry
+      liveAppBetas <- combineModels(buildsResponse)
+    } yield liveAppBetas
   }
 
 }

--- a/src/main/scala/com/gu/appstoreconnectapi/Conversion.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/Conversion.scala
@@ -1,0 +1,38 @@
+package com.gu.appstoreconnectapi
+
+import java.time.ZonedDateTime
+
+import com.gu.appstoreconnectapi.AppStoreConnectApi.BuildsResponse
+
+import scala.util.{Failure, Success, Try}
+
+object Conversion {
+
+  case class LiveAppBeta(version: String, uploadedDate: ZonedDateTime, internalBuildState: String, externalBuildState: String)
+
+  case object CombinedResponseException extends Throwable
+
+  // App Store Connect API provides two different objects which can be matched by id
+  // Since we need data from both objects we combine them into a single case class here
+  // to avoid scattering this matching logic throughout the codebase
+  def combineModels(buildsResponse: BuildsResponse): Try[List[LiveAppBeta]] = {
+    val buildDetailsIds = buildsResponse.data.map(_.id)
+    val betaBuildDetailsIds = buildsResponse.included.map(_.id)
+    if (buildDetailsIds != betaBuildDetailsIds) {
+      Failure(CombinedResponseException)
+    } else {
+      val liveAppBetas = buildsResponse.data.map {
+        buildDetails =>
+          val betaBuildDetails = buildsResponse.included.find(_.id == buildDetails.id).get
+          LiveAppBeta(
+            version = buildDetails.attributes.version,
+            uploadedDate = buildDetails.attributes.uploadedDate,
+            internalBuildState = betaBuildDetails.attributes.internalBuildState,
+            externalBuildState = betaBuildDetails.attributes.externalBuildState,
+          )
+      }
+      Success(liveAppBetas)
+    }
+  }
+
+}

--- a/src/main/scala/com/gu/githubapi/Conversion.scala
+++ b/src/main/scala/com/gu/githubapi/Conversion.scala
@@ -1,0 +1,15 @@
+package com.gu.githubapi
+
+import com.gu.githubapi.GitHubApi.Deployment
+
+object Conversion {
+
+  case class RunningLiveAppDeployment(version: String, environment: String, gitHubDatabaseId: Int)
+
+  def runningLiveAppDeployments(gitHubDeployments: List[Deployment]): List[RunningLiveAppDeployment] = {
+    gitHubDeployments
+      .filter(deployment => deployment.state == "PENDING" && deployment.latestStatus.flatMap(_.description).isDefined)
+      .map(deployment => RunningLiveAppDeployment(deployment.latestStatus.get.description.get, deployment.environment, deployment.databaseId))
+  }
+
+}

--- a/src/main/scala/com/gu/githubapi/GitHubApi.scala
+++ b/src/main/scala/com/gu/githubapi/GitHubApi.scala
@@ -56,21 +56,4 @@ object GitHubApi {
     }
   }
 
-  def markDeploymentAsSuccess(gitHubConfig: GitHubConfig, deploymentId: String): Try[Response] = {
-    val statusUpdate =
-      """
-        |{
-        |	"state": "success",
-        |	"description": "123"
-        |}
-        |""".stripMargin
-    val path = s"/guardian/ios-live/deployments/$deploymentId/statuses"
-    val attempt = Try(SharedClient.client.newCall(gitHubPostRequest(s"$restApiUrl/$path", statusUpdate, gitHubConfig)).execute)
-    attempt match {
-      case Success(response) if !response.isSuccessful => Failure(
-        GitHubApiException(s"Response code: ${response.code()} | response body: ${response.body().string()}"))
-      case _ => attempt
-    }
-  }
-
 }

--- a/src/main/scala/com/gu/githubapi/GitHubApi.scala
+++ b/src/main/scala/com/gu/githubapi/GitHubApi.scala
@@ -6,9 +6,9 @@ import com.gu.okhttp.SharedClient
 import io.circe.Decoder
 import io.circe.parser._
 import io.circe.generic.auto._
-import okhttp3.{ MediaType, Request, RequestBody, Response, ResponseBody }
+import okhttp3.{ MediaType, Request, RequestBody }
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.Try
 
 object GitHubApi {
 

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -1,8 +1,13 @@
 package com.gu.iosdeployments
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.config.Config.Env
+import com.gu.appstoreconnectapi.Conversion.LiveAppBeta
+import com.gu.appstoreconnectapi.{ AppStoreConnectApi, JwtTokenBuilder }
+import com.gu.config.Config.{ AppStoreConnectConfig, Env, GitHubConfig }
+import com.gu.githubapi.GitHubApi
 import org.slf4j.{ Logger, LoggerFactory }
+
+import scala.util.{ Failure, Success }
 
 object Lambda {
 
@@ -15,7 +20,43 @@ object Lambda {
   }
 
   def process(env: Env): Unit = {
-    logger.info("Hello world")
-  }
+    logger.info("Loading configuration...")
+    val appStoreConnectConfig = AppStoreConnectConfig(env)
+    val appStoreConnectToken = JwtTokenBuilder.buildToken(appStoreConnectConfig)
+    val gitHubConfig = GitHubConfig(env)
+    logger.info("Successfully loaded configuration...")
+    val result = for {
+      runningDeployments <- GitHubApi.getRunningDeployments(gitHubConfig)
+      appStoreConnectBetaBuilds <- AppStoreConnectApi.getLatestBetaBuilds(appStoreConnectToken, appStoreConnectConfig)
+    } yield {
+      // Process one running deployment per lambda execution
+      // In practice it's extremely unlikely that there will be two concurrent deployments anyway
+      runningDeployments.headOption match {
+        case Some(runningDeployment) =>
+          val attemptToFindBeta = appStoreConnectBetaBuilds.find(_.version == runningDeployment.version)
+          (runningDeployment.environment, attemptToFindBeta) match {
+            case ("internal-beta", Some(LiveAppBeta(_, _, "IN_BETA_TESTING", _))) =>
+              logger.info(s"Internal beta deployment for ${runningDeployment.version} is complete...")
+            // GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment.databaseId)
+            case ("external-beta", Some(LiveAppBeta(_, _, _, "IN_BETA_TESTING"))) =>
+              logger.info(s"External beta deployment for ${runningDeployment.version} is complete...")
+            // GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment.databaseId)
+            case ("external-beta", Some(LiveAppBeta(_, _, _, "READY_FOR_TESTING"))) =>
+              logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
+            // Distribute to external testers here
+            case (_, None) =>
+              logger.info(s"Found running deployment ${runningDeployment.version}, but build was not present in App Store Connect response")
+            case _ =>
+              logger.info(s"No action was required for ${runningDeployment.version}")
+          }
+        case None => logger.info("No running deployments found.")
+      }
+    }
 
+    result match {
+      case Success(_) => logger.info("Successfully checked deployment status")
+      case Failure(exception) => logger.error(s"Failed to check deployment status due to: ${exception}", exception)
+    }
+
+  }
 }

--- a/src/main/scala/com/gu/liveappversions/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/Lambda.scala
@@ -21,8 +21,8 @@ object Lambda {
     val appStoreConnectConfig = AppStoreConnectConfig(env)
     val token = JwtTokenBuilder.buildToken(appStoreConnectConfig)
     val attempt = for {
-      appStoreConnectResponse <- AppStoreConnectApi.getLatestBetaBuilds(token, appStoreConnectConfig)
-      buildOutput <- BuildOutput.fromAppStoreConnectResponse(appStoreConnectResponse)
+      latestBetas <- AppStoreConnectApi.getLatestBetaBuilds(token, appStoreConnectConfig)
+      buildOutput <- BuildOutput.findLatestBuildsWithExternalTesters(latestBetas)
       uploadAttempt <- S3Uploader.attemptUpload(buildOutput, env, uploadBucketName)
     } yield uploadAttempt
     attempt match {

--- a/src/main/scala/com/gu/okhttp/SharedClient.scala
+++ b/src/main/scala/com/gu/okhttp/SharedClient.scala
@@ -1,0 +1,24 @@
+package com.gu.okhttp
+
+import okhttp3.{ OkHttpClient, Response }
+import scala.util.{ Failure, Success, Try }
+
+case class ApiException(message: String) extends Throwable(message: String)
+
+object SharedClient {
+
+  val client = new OkHttpClient
+
+  def getResponseBodyIfSuccessful(apiName: String, response: Response): Try[String] = {
+    val responseBody = response.body().string()
+    response.body().close() //https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/#the-response-body-must-be-closed
+    if (!response.isSuccessful) {
+      Failure(
+        ApiException(
+          s"Received an unsuccessful response from $apiName. Response code: ${response.code()} | response body: ${responseBody}"))
+    } else {
+      Success(responseBody)
+    }
+  }
+
+}

--- a/src/test/scala/com/gu/appstoreconnectapi/ConversionTest.scala
+++ b/src/test/scala/com/gu/appstoreconnectapi/ConversionTest.scala
@@ -1,0 +1,53 @@
+package com.gu.appstoreconnectapi
+
+import java.time.ZonedDateTime
+import com.gu.appstoreconnectapi.AppStoreConnectApi.{ BetaBuildAttributes, BetaBuildDetails, BuildAttributes, BuildDetails, BuildsResponse }
+import com.gu.appstoreconnectapi.Conversion.LiveAppBeta
+import org.scalatest.FunSuite
+
+import scala.util.{ Failure, Success }
+
+class ConversionTest extends FunSuite {
+
+  val now = ZonedDateTime.now()
+  val buildDetails = BuildDetails("id123", BuildAttributes("12345", now))
+  val betaBuildDetails = BetaBuildDetails("id123", BetaBuildAttributes(internalBuildState = "INTERNAL", externalBuildState = "EXTERNAL"))
+
+  val allBuildDetails = List(
+    buildDetails,
+    buildDetails.copy(id = "id124").copy(attributes = BuildAttributes("12344", now)),
+    buildDetails.copy(id = "id125").copy(attributes = BuildAttributes("12343", now)),
+    buildDetails.copy(id = "id126").copy(attributes = BuildAttributes("12342", now)),
+    buildDetails.copy(id = "id127").copy(attributes = BuildAttributes("12341", now)))
+  val allBetaBuildDetails = List(
+    betaBuildDetails,
+    betaBuildDetails.copy(id = "id124"),
+    betaBuildDetails.copy(id = "id125"),
+    betaBuildDetails.copy(id = "id126"),
+    betaBuildDetails.copy(id = "id127"))
+
+  test("combineModels should produce a list of LiveAppBetas from a valid App Store Connect response") {
+    val buildsResponse = BuildsResponse(allBuildDetails, allBetaBuildDetails)
+    val result = Conversion.combineModels(buildsResponse)
+    val expectedResults = List(
+      LiveAppBeta("12345", now, "INTERNAL", "EXTERNAL"),
+      LiveAppBeta("12344", now, "INTERNAL", "EXTERNAL"),
+      LiveAppBeta("12343", now, "INTERNAL", "EXTERNAL"),
+      LiveAppBeta("12342", now, "INTERNAL", "EXTERNAL"),
+      LiveAppBeta("12341", now, "INTERNAL", "EXTERNAL"))
+    assert(result == Success(expectedResults))
+  }
+
+  test("combineModels should fail if there are objects missing from the App Store Connect response") {
+    val buildsResponse = BuildsResponse(allBuildDetails.drop(1), allBetaBuildDetails)
+    val result = Conversion.combineModels(buildsResponse)
+    assert(result.isFailure)
+  }
+
+  test("combineModels should fail if the ids in the App Store Connect response do not match") {
+    val buildsResponse = BuildsResponse(List(buildDetails), List(betaBuildDetails.copy(id = "fakeId")))
+    val result = Conversion.combineModels(buildsResponse)
+    assert(result.isFailure)
+  }
+
+}

--- a/src/test/scala/com/gu/githubapi/ConversionTest.scala
+++ b/src/test/scala/com/gu/githubapi/ConversionTest.scala
@@ -1,0 +1,36 @@
+package com.gu.githubapi
+
+import com.gu.githubapi.Conversion.RunningLiveAppDeployment
+import com.gu.githubapi.GitHubApi.{ Deployment, LatestStatus }
+import org.scalatest.FunSuite
+
+class ConversionTest extends FunSuite {
+
+  val deployment = Deployment(
+    123,
+    "external-beta",
+    "PENDING",
+    Some(LatestStatus(Some("12345"))))
+
+  test("runningLiveAppDeployments should collect pending deployments with version info") {
+    val result = Conversion.runningLiveAppDeployments(List(deployment))
+    val expected = List(RunningLiveAppDeployment("12345", "external-beta", 123))
+    assert(result == expected)
+  }
+
+  test("runningLiveAppDeployments should discard completed deployments") {
+    val completedDeployment = deployment.copy(state = "SUCCESSFUL")
+    val result = Conversion.runningLiveAppDeployments(List(completedDeployment))
+    val expected = List()
+    assert(result == expected)
+  }
+
+  test("runningLiveAppDeployments should discard pending deployments which do not contain version info") {
+    val deploymentOnCreation = deployment.copy(latestStatus = None)
+    val deploymentWithUnexpectedStatusUpdate = deployment.copy(latestStatus = Some(LatestStatus(None)))
+    val result = Conversion.runningLiveAppDeployments(List(deploymentOnCreation, deploymentWithUnexpectedStatusUpdate))
+    val expected = List()
+    assert(result == expected)
+  }
+
+}

--- a/src/test/scala/com/gu/githubapi/GitHubApiTest.scala
+++ b/src/test/scala/com/gu/githubapi/GitHubApiTest.scala
@@ -1,0 +1,13 @@
+package com.gu.githubapi
+
+import org.scalatest.FunSuite
+
+class GitHubApiTest extends FunSuite {
+
+  test("The deployments JSON from GitHub should parse correctly") {
+    val fakeResponseBody = """{"data":{"repository":{"deployments":{"edges":[{"node":{"databaseId":123,"createdAt":"2020-04-27T08:04:15Z","environment":"external-beta","state":"ABANDONED","payload":null,"latestStatus":null}},{"node":{"databaseId":124,"createdAt":"2020-04-27T08:19:08Z","environment":"external-beta","state":"ABANDONED","payload":null,"latestStatus":null}},{"node":{"databaseId":125,"createdAt":"2020-04-27T08:27:46Z","environment":"external-beta","state":"PENDING","payload":null,"latestStatus":{"createdAt":"2020-04-27T08:30:46Z","description":"17797"}}}]}}}}"""
+    val result = GitHubApi.extractDeployments(fakeResponseBody)
+    assert(result.isRight)
+  }
+
+}

--- a/src/test/scala/com/gu/iosdeployments/integration/IntegrationTest.scala
+++ b/src/test/scala/com/gu/iosdeployments/integration/IntegrationTest.scala
@@ -1,0 +1,12 @@
+package com.gu.iosdeployments.integration
+
+import com.gu.config.Config.Env
+import com.gu.iosdeployments.Lambda
+
+object IntegrationTest {
+
+  def main(args: Array[String]): Unit = {
+    Lambda.process(Env())
+  }
+
+}

--- a/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
+++ b/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
@@ -2,105 +2,52 @@ package com.gu.liveappversions
 
 import java.time.ZonedDateTime
 
-import com.gu.appstoreconnectapi.AppStoreConnectApi.{BetaBuildAttributes, BetaBuildDetails, BuildAttributes, BuildDetails, BuildsResponse}
+import com.gu.appstoreconnectapi.Conversion.LiveAppBeta
 import org.scalatest.FunSuite
 
 class BuildOutputTest extends FunSuite {
 
   val now = ZonedDateTime.now()
 
-  val releasedToExternalBetaDetails = BetaBuildDetails("id123", BetaBuildAttributes("IN_BETA_TESTING"))
-  val releasedToExternalBuildDetails = BuildDetails("id123", BuildAttributes("8.16 (5)", now))
-
-  val unreleasedToExternalBetaDetails = BetaBuildDetails("id999", BetaBuildAttributes("IN_REVIEW"))
-  val unreleasedToExternalBuildDetails = BuildDetails("id999", BuildAttributes("8.16 (56)", now))
+  val releasedToExternalBeta = LiveAppBeta("12349", now, "IN_BETA_TESTING", "IN_BETA_TESTING")
+  val unreleasedToExternalBeta = LiveAppBeta("22349", now, "IN_BETA_TESTING", "IN_REVIEW")
 
   test("findLatestBuildsWithExternalTesters should correctly identify the 4 most recent beta versions from Apple's response") {
-    val buildDetails = List(
-      releasedToExternalBuildDetails,
-      releasedToExternalBuildDetails.copy(id = "id124").copy(attributes = BuildAttributes("8.16 (4)", now)),
-      releasedToExternalBuildDetails.copy(id = "id125").copy(attributes = BuildAttributes("8.16 (3)", now)),
-      releasedToExternalBuildDetails.copy(id = "id126").copy(attributes = BuildAttributes("8.16 (2)", now)),
-      releasedToExternalBuildDetails.copy(id = "id127").copy(attributes = BuildAttributes("8.16 (1)", now))
-    )
-    val betaDetails = List(
-      releasedToExternalBetaDetails,
-      releasedToExternalBetaDetails.copy(id = "id124"),
-      releasedToExternalBetaDetails.copy(id = "id125"),
-      releasedToExternalBetaDetails.copy(id = "id126"),
-      releasedToExternalBetaDetails.copy(id = "id127")
-    )
-    val buildsResponse = BuildsResponse(buildDetails, betaDetails)
-    val result = BuildOutput.findLatestBuildsWithExternalTesters(buildsResponse)
 
-    assert(result.get.latestReleasedBuild.version === "8.16 (5)")
-    assert(result.get.previouslyReleasedBuilds.map(_.version) === List("8.16 (4)", "8.16 (3)", "8.16 (2)"))
+    val betaBuilds = List(
+      releasedToExternalBeta,
+      releasedToExternalBeta.copy("12348"),
+      releasedToExternalBeta.copy("12347"),
+      releasedToExternalBeta.copy("12346"),
+      releasedToExternalBeta.copy("12345"))
+
+    val result = BuildOutput.findLatestBuildsWithExternalTesters(betaBuilds)
+
+    assert(result.get.latestReleasedBuild.version === "12349")
+    assert(result.get.previouslyReleasedBuilds.map(_.version) === List("12348", "12347", "12346"))
 
   }
 
   test("findLatestBuildsWithExternalTesters should ignore betas which have NOT been released to external testers") {
-    val buildDetails = List(
-      unreleasedToExternalBuildDetails,
-      releasedToExternalBuildDetails,
-      releasedToExternalBuildDetails.copy(id = "id124").copy(attributes = BuildAttributes("8.16 (4)", now)),
-      releasedToExternalBuildDetails.copy(id = "id125").copy(attributes = BuildAttributes("8.16 (3)", now)),
-      releasedToExternalBuildDetails.copy(id = "id126").copy(attributes = BuildAttributes("8.16 (2)", now)),
-    )
-    val betaDetails = List(
-      unreleasedToExternalBetaDetails,
-      releasedToExternalBetaDetails,
-      releasedToExternalBetaDetails.copy(id = "id124"),
-      releasedToExternalBetaDetails.copy(id = "id125"),
-      releasedToExternalBetaDetails.copy(id = "id126")
-    )
-    val buildsResponse = BuildsResponse(buildDetails, betaDetails)
-    val result = BuildOutput.findLatestBuildsWithExternalTesters(buildsResponse)
+    val betaBuilds = List(
+      unreleasedToExternalBeta,
+      releasedToExternalBeta,
+      releasedToExternalBeta.copy("12348"),
+      releasedToExternalBeta.copy("12347"),
+      releasedToExternalBeta.copy("12346"))
+    val result = BuildOutput.findLatestBuildsWithExternalTesters(betaBuilds)
 
-    assert(result.get.latestReleasedBuild.version === "8.16 (5)")
-    assert(result.get.previouslyReleasedBuilds.map(_.version) === List("8.16 (4)", "8.16 (3)", "8.16 (2)"))
+    assert(result.get.latestReleasedBuild.version === "12349")
+    assert(result.get.previouslyReleasedBuilds.map(_.version) === List("12348", "12347", "12346"))
 
   }
 
   test("findLatestBuildsWithExternalTesters should fail if there are less than 4 recent beta versions") {
-    val buildDetails = List(releasedToExternalBuildDetails, releasedToExternalBuildDetails, releasedToExternalBuildDetails)
-    val betaDetails = List(releasedToExternalBetaDetails, releasedToExternalBetaDetails, releasedToExternalBetaDetails)
-    val buildsResponse = BuildsResponse(buildDetails, betaDetails)
-    val result = BuildOutput.findLatestBuildsWithExternalTesters(buildsResponse)
-    assert(result.isFailure)
-  }
-
-  test("findLatestBuildsWithExternalTesters should fail if it cannot find the version name for the most recent beta") {
-    val buildDetails = List(
-      releasedToExternalBuildDetails.copy("fakeId"),
-      releasedToExternalBuildDetails.copy(id = "id124").copy(attributes = BuildAttributes("8.16 (4)", now)),
-      releasedToExternalBuildDetails.copy(id = "id125").copy(attributes = BuildAttributes("8.16 (3)", now)),
-      releasedToExternalBuildDetails.copy(id = "id126").copy(attributes = BuildAttributes("8.16 (2)", now)),
-    )
-    val betaDetails = List(
-      releasedToExternalBetaDetails,
-      releasedToExternalBetaDetails.copy(id = "id124"),
-      releasedToExternalBetaDetails.copy(id = "id125"),
-      releasedToExternalBetaDetails.copy(id = "id126")
-    )
-    val buildsResponse = BuildsResponse(buildDetails, betaDetails)
-    val result = BuildOutput.findLatestBuildsWithExternalTesters(buildsResponse)
-    assert(result.isFailure)
-  }
-
-  test("findPreviousThreeBetaVersions should fail if it finds less than 3 previous versions (due to mismatched ids)") {
-    val allBetas = List(
-      releasedToExternalBetaDetails,
-      releasedToExternalBetaDetails.copy(id = "id124"),
-      releasedToExternalBetaDetails.copy(id = "id125"),
-      releasedToExternalBetaDetails.copy(id = "id126")
-    )
-    val buildDetails = List(
-      releasedToExternalBuildDetails,
-      releasedToExternalBuildDetails.copy(id = "id127"),
-      releasedToExternalBuildDetails.copy(id = "id128"),
-      releasedToExternalBuildDetails.copy(id = "id129"),
-    )
-    val result = BuildOutput.findPreviousThreeBetaVersions(allBetas, buildDetails)
+    val betaBuilds = List(
+      releasedToExternalBeta,
+      releasedToExternalBeta.copy("12348"),
+      releasedToExternalBeta.copy("12347"))
+    val result = BuildOutput.findLatestBuildsWithExternalTesters(betaBuilds)
     assert(result.isFailure)
   }
 


### PR DESCRIPTION
**Motivation for adding new functionality:**

iOS deployments are long-running tasks. After uploading builds to App Store Connect, you must (separately) distribute builds to external users. Unfortunately Apple does not provide a webhook (or similar) to notify us when a build becomes ready for distribution, which means that the deployment system must poll whilst waiting for the uploaded build to become ready. The time it takes for a build to become ready for distribution is unpredictable, but it often takes longer than an hour.

Our current solution for iOS deployments uses CI to poll the App Store Connect API whilst waiting for the the build to become ready. This is problematic for two main reasons:

1) We now [pay by the minute for CI](https://help.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions#about-billing-for-github-actions), so this solution is not cost-effective.
2) Transient issues with the App Store Connect API can cause polling to fail, which often leaves us with incomplete deploys that must be fixed manually.

**Proposed solution:**

As part of each upload to App Store Connect, our CI system will trigger a [GitHub deployment](https://developer.github.com/v3/repos/deployments/) event and annotate it with the build number.

A new lambda (added in https://github.com/guardian/live-app-versions/pull/11 and fleshed out a bit in this PR) will poll the GitHub deployments API and the App Store Connect API. When it finds a running deployment, it will check whether the build associated with the deployment can (and should) be distributed or not. In this PR we simply check which action should be performed and log it; write operations will be added in a subsequent PR. 

**Other changes in this PR:**

* Refactors the App Store Connect code to a) use a shared `OkHttpClient` and b) adopt a model which is easier to work with (see: https://github.com/guardian/live-app-versions/commit/82fa16f0b5f3ec04575cf44a9fb42427ea586259).

**Remaining work:**

* Write operations! E.g. Marking deploys as successful or failed (in GitHub), and actually distributing the builds when they become ready.