### PR TITLE
Add functionality for updating GitHub Deployment status

### DIFF
--- a/src/main/scala/com/gu/githubapi/GitHubApi.scala
+++ b/src/main/scala/com/gu/githubapi/GitHubApi.scala
@@ -56,4 +56,21 @@ object GitHubApi {
     }
   }
 
+  def markDeploymentAsSuccess(gitHubConfig: GitHubConfig, deployment: RunningLiveAppDeployment): Try[Unit] = {
+    val url = s"$restApiUrl/repos/guardian/ios-live/deployments/${deployment.gitHubDatabaseId.toString}/statuses"
+    val body =
+      s"""
+        |{
+        |  "state": "success",
+        |  "description": "${deployment.version}"
+        |}
+        |""".stripMargin
+    for {
+      httpResponse <- Try(SharedClient.client.newCall(gitHubPostRequest(url, body, gitHubConfig)).execute)
+      _ <- SharedClient.getResponseBodyIfSuccessful("GitHub API", httpResponse)
+    } yield {
+      ()
+    }
+  }
+
 }

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -37,10 +37,10 @@ object Lambda {
           (runningDeployment.environment, attemptToFindBeta) match {
             case ("internal-beta", Some(LiveAppBeta(_, _, "IN_BETA_TESTING", _))) =>
               logger.info(s"Internal beta deployment for ${runningDeployment.version} is complete...")
-            // GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment.databaseId)
+              GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)
             case ("external-beta", Some(LiveAppBeta(_, _, _, "IN_BETA_TESTING"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} is complete...")
-            // GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment.databaseId)
+              GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)
             case ("external-beta", Some(LiveAppBeta(_, _, _, "READY_FOR_TESTING"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
             // Distribute to external testers here
@@ -54,8 +54,8 @@ object Lambda {
     }
 
     result match {
-      case Success(_) => logger.info("Successfully checked deployment status")
-      case Failure(exception) => logger.error(s"Failed to check deployment status due to: ${exception}", exception)
+      case Success(_) => logger.info("Successfully checked/updated deployment status")
+      case Failure(exception) => logger.error(s"Failed to check or update deployment status due to: ${exception}", exception)
     }
 
   }


### PR DESCRIPTION
Follow up to https://github.com/guardian/live-app-versions/pull/12 and https://github.com/guardian/ios-live/pull/5150.

Still to come: distributing builds to external testers automatically.