### PR TITLE
Automatically submit betas for review and distribute externally

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -57,7 +57,7 @@ object AppStoreConnectApi {
     val body = s"""
                   |{
                   |  "data": {
-                  |    "id": "${externalTesterGroup.id}"
+                  |    "id": "${externalTesterGroup.id}",
                   |    "type": "betaGroups"
                   |  }
                   |}

--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -50,16 +50,22 @@ object AppStoreConnectApi {
     } yield liveAppBetas
   }
 
-  def distributeToExternalTesterGroup(token: String, buildId: String, externalTesterGroup: ExternalTesterGroup): Try[Unit] = {
+  def distributeToExternalTesters(token: String, buildId: String, externalTesterConfig: ExternalTesterConfig): Try[Unit] = {
 
     val url = s"$appStoreConnectBaseUrl/builds/$buildId/relationships/betaGroups"
 
     val body = s"""
                   |{
-                  |  "data": {
-                  |    "id": "${externalTesterGroup.id}",
-                  |    "type": "betaGroups"
-                  |  }
+                  |  "data": [
+                  |     {
+                  |       "id": "${externalTesterConfig.group1.id}",
+                  |         "type": "betaGroups"
+                  |     },
+                  |     {
+                  |       "id": "${externalTesterConfig.group2.id}",
+                  |         "type": "betaGroups"
+                  |     }
+                  |  ]
                   |}
                   |""".stripMargin
     val request = new Request.Builder()
@@ -71,15 +77,8 @@ object AppStoreConnectApi {
       httpResponse <- Try(SharedClient.client.newCall(request).execute)
       _ <- SharedClient.getResponseBodyIfSuccessful("App Store Connect API", httpResponse)
     } yield {
-      logger.info(s"Successfully distributed build to $externalTesterGroup")
+      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1} and ${externalTesterConfig.group2}")
     }
-  }
-
-  def distributeToExternalTesters(token: String, buildId: String, externalTesterConfig: ExternalTesterConfig): Try[Unit] = {
-    for {
-      group1 <- distributeToExternalTesterGroup(token, buildId, externalTesterConfig.group1)
-      group2 <- distributeToExternalTesterGroup(token, buildId, externalTesterConfig.group2)
-    } yield ()
   }
 
 }

--- a/src/main/scala/com/gu/appstoreconnectapi/Conversion.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/Conversion.scala
@@ -8,7 +8,7 @@ import scala.util.{Failure, Success, Try}
 
 object Conversion {
 
-  case class LiveAppBeta(version: String, uploadedDate: ZonedDateTime, internalBuildState: String, externalBuildState: String)
+  case class LiveAppBeta(version: String, buildId: String, uploadedDate: ZonedDateTime, internalBuildState: String, externalBuildState: String)
 
   case object CombinedResponseException extends Throwable
 
@@ -26,6 +26,7 @@ object Conversion {
           val betaBuildDetails = buildsResponse.included.find(_.id == buildDetails.id).get
           LiveAppBeta(
             version = buildDetails.attributes.version,
+            buildId = buildDetails.id,
             uploadedDate = buildDetails.attributes.uploadedDate,
             internalBuildState = betaBuildDetails.attributes.internalBuildState,
             externalBuildState = betaBuildDetails.attributes.externalBuildState,

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -53,10 +53,10 @@ object Config {
 
   case class ExternalTesterGroup(id: String, name: String)
   case class ExternalTesterConfig(group1: ExternalTesterGroup, group2: ExternalTesterGroup)
-  val externalTesterConfigForTesting = ExternalTesterConfig(
+  val externalTesterConfigForProd = ExternalTesterConfig(
     ExternalTesterGroup("b3ee0d21-fe7e-487a-9f81-5ea993b6e860", "External Testers 1"),
     ExternalTesterGroup("53ab9951-d444-4107-87ce-dbfbb2c898e5", "External Testers 2"))
-  val externalTesterConfigForProd = ExternalTesterConfig(
+  val externalTesterConfigForTesting = ExternalTesterConfig(
     ExternalTesterGroup("2c761621-6849-46c5-a936-fecc1187d736", "Live App Versions Testers 1"),
     ExternalTesterGroup("d3fc87fc-7416-41ae-8ff9-2a1d8a6c619a", "Live App Versions Testers 2"))
 

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -51,6 +51,15 @@ object Config {
     }
   }
 
+  case class ExternalTesterGroup(id: String, name: String)
+  case class ExternalTesterConfig(group1: ExternalTesterGroup, group2: ExternalTesterGroup)
+  val externalTesterConfigForTesting = ExternalTesterConfig(
+    ExternalTesterGroup("b3ee0d21-fe7e-487a-9f81-5ea993b6e860", "External Testers 1"),
+    ExternalTesterGroup("53ab9951-d444-4107-87ce-dbfbb2c898e5", "External Testers 2"))
+  val externalTesterConfigForProd = ExternalTesterConfig(
+    ExternalTesterGroup("2c761621-6849-46c5-a936-fecc1187d736", "Live App Versions Testers 1"),
+    ExternalTesterGroup("d3fc87fc-7416-41ae-8ff9-2a1d8a6c619a", "Live App Versions Testers 2"))
+
   case class GitHubConfig(token: String)
 
   object GitHubConfig {

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -39,13 +39,13 @@ object Lambda {
           (runningDeployment.environment, attemptToFindBeta) match {
             case ("internal-beta", Some(LiveAppBeta(_, _, _, "IN_BETA_TESTING", _))) =>
               logger.info(s"Internal beta deployment for ${runningDeployment.version} is complete...")
-              GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)
+              GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment).get
             case ("external-beta", Some(LiveAppBeta(_, _, _, _, "IN_BETA_TESTING"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} is complete...")
-              GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)
+              GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment).get
             case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "READY_FOR_BETA_SUBMISSION"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
-              AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig)
+              AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig).get
             case (_, None) =>
               logger.info(s"Found running deployment ${runningDeployment.version}, but build was not present in App Store Connect response")
             case _ =>
@@ -55,7 +55,7 @@ object Lambda {
       }
     }
 
-    result.flatten match {
+    result match {
       case Success(_) => logger.info("Successfully checked/updated deployment status")
       case Failure(exception) => logger.error(s"Failed to check or update deployment status due to: ${exception}", exception)
     }

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -49,7 +49,7 @@ object Lambda {
             case (_, None) =>
               logger.info(s"Found running deployment ${runningDeployment.version}, but build was not present in App Store Connect response")
             case _ =>
-              logger.info(s"No action was required for ${runningDeployment.version}")
+              logger.info(s"No action was required for ${runningDeployment.version}. Full details are: $runningDeployment")
           }
         case None => logger.info("No running deployments found.")
       }

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -43,7 +43,7 @@ object Lambda {
             case ("external-beta", Some(LiveAppBeta(_, _, _, _, "IN_BETA_TESTING"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} is complete...")
               GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment).get
-            case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "READY_FOR_BETA_SUBMISSION"))) =>
+            case ("external-beta", Some(build @ LiveAppBeta(_, _, _, "IN_BETA_TESTING", "READY_FOR_BETA_SUBMISSION"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} can now be submitted for review...")
               AppStoreConnectApi.submitForBetaTesting(appStoreConnectToken, build.buildId).get
             case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "READY_FOR_BETA_TESTING"))) =>

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -44,6 +44,9 @@ object Lambda {
               logger.info(s"External beta deployment for ${runningDeployment.version} is complete...")
               GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment).get
             case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "READY_FOR_BETA_SUBMISSION"))) =>
+              logger.info(s"External beta deployment for ${runningDeployment.version} can now be submitted for review...")
+              AppStoreConnectApi.submitForBetaTesting(appStoreConnectToken, build.buildId).get
+            case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "READY_FOR_BETA_TESTING"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
               AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig).get
             case (_, None) =>

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -8,7 +8,7 @@ import com.gu.config.Config.{ AppStoreConnectConfig, Env, GitHubConfig }
 import com.gu.githubapi.GitHubApi
 import org.slf4j.{ Logger, LoggerFactory }
 
-import scala.util.{ Failure, Success }
+import scala.util.{ Failure, Success, Try }
 
 object Lambda {
 
@@ -55,7 +55,7 @@ object Lambda {
       }
     }
 
-    result match {
+    result.flatten match {
       case Success(_) => logger.info("Successfully checked/updated deployment status")
       case Failure(exception) => logger.error(s"Failed to check or update deployment status due to: ${exception}", exception)
     }

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -46,7 +46,7 @@ object Lambda {
             case ("external-beta", Some(build @ LiveAppBeta(_, _, _, "IN_BETA_TESTING", "READY_FOR_BETA_SUBMISSION"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} can now be submitted for review...")
               AppStoreConnectApi.submitForBetaTesting(appStoreConnectToken, build.buildId).get
-            case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "READY_FOR_BETA_TESTING"))) =>
+            case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "BETA_APPROVED"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
               AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig).get
             case (_, None) =>

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -49,7 +49,7 @@ object Lambda {
             case (_, None) =>
               logger.info(s"Found running deployment ${runningDeployment.version}, but build was not present in App Store Connect response")
             case _ =>
-              logger.info(s"No action was required for ${runningDeployment.version}. Full details are: $runningDeployment")
+              logger.info(s"No action was required for ${runningDeployment.version}. Full details are: $attemptToFindBeta")
           }
         case None => logger.info("No running deployments found.")
       }

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -43,7 +43,7 @@ object Lambda {
             case ("external-beta", Some(LiveAppBeta(_, _, _, _, "IN_BETA_TESTING"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} is complete...")
               GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)
-            case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "READY_FOR_TESTING"))) =>
+            case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "READY_FOR_BETA_SUBMISSION"))) =>
               logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
               AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig)
             case (_, None) =>

--- a/src/main/scala/com/gu/okhttp/SharedClient.scala
+++ b/src/main/scala/com/gu/okhttp/SharedClient.scala
@@ -1,11 +1,15 @@
 package com.gu.okhttp
 
-import okhttp3.{ OkHttpClient, Response }
-import scala.util.{ Failure, Success, Try }
+import okhttp3.{OkHttpClient, Response}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.util.{Failure, Success, Try}
 
 case class ApiException(message: String) extends Throwable(message: String)
 
 object SharedClient {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   val client = new OkHttpClient
 
@@ -13,10 +17,11 @@ object SharedClient {
     val responseBody = response.body().string()
     response.body().close() //https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/#the-response-body-must-be-closed
     if (!response.isSuccessful) {
-      Failure(
-        ApiException(
-          s"Received an unsuccessful response from $apiName. Response code: ${response.code()} | response body: ${responseBody}"))
+      val message = s"Received an unsuccessful response from $apiName. Response code: ${response.code()} | response body: ${responseBody}"
+      logger.warn(message)
+      Failure(ApiException(message))
     } else {
+      logger.info(s"Received successful response from $apiName. Response code: ${response.code()} | response body: ${responseBody}")
       Success(responseBody)
     }
   }

--- a/src/main/scala/com/gu/okhttp/SharedClient.scala
+++ b/src/main/scala/com/gu/okhttp/SharedClient.scala
@@ -1,9 +1,9 @@
 package com.gu.okhttp
 
-import okhttp3.{OkHttpClient, Response}
-import org.slf4j.{Logger, LoggerFactory}
+import okhttp3.{ OkHttpClient, Response }
+import org.slf4j.{ Logger, LoggerFactory }
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 case class ApiException(message: String) extends Throwable(message: String)
 
@@ -21,7 +21,7 @@ object SharedClient {
       logger.warn(message)
       Failure(ApiException(message))
     } else {
-      logger.info(s"Received successful response from $apiName. Response code: ${response.code()} | response body: ${responseBody}")
+      logger.info(s"Received successful response from $apiName. Response code: ${response.code()}")
       Success(responseBody)
     }
   }

--- a/src/test/scala/com/gu/appstoreconnectapi/ConversionTest.scala
+++ b/src/test/scala/com/gu/appstoreconnectapi/ConversionTest.scala
@@ -30,11 +30,11 @@ class ConversionTest extends FunSuite {
     val buildsResponse = BuildsResponse(allBuildDetails, allBetaBuildDetails)
     val result = Conversion.combineModels(buildsResponse)
     val expectedResults = List(
-      LiveAppBeta("12345", now, "INTERNAL", "EXTERNAL"),
-      LiveAppBeta("12344", now, "INTERNAL", "EXTERNAL"),
-      LiveAppBeta("12343", now, "INTERNAL", "EXTERNAL"),
-      LiveAppBeta("12342", now, "INTERNAL", "EXTERNAL"),
-      LiveAppBeta("12341", now, "INTERNAL", "EXTERNAL"))
+      LiveAppBeta("12345", "id123", now, "INTERNAL", "EXTERNAL"),
+      LiveAppBeta("12344", "id124", now, "INTERNAL", "EXTERNAL"),
+      LiveAppBeta("12343", "id125", now, "INTERNAL", "EXTERNAL"),
+      LiveAppBeta("12342", "id126", now, "INTERNAL", "EXTERNAL"),
+      LiveAppBeta("12341", "id127", now, "INTERNAL", "EXTERNAL"))
     assert(result == Success(expectedResults))
   }
 

--- a/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
+++ b/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
@@ -9,8 +9,8 @@ class BuildOutputTest extends FunSuite {
 
   val now = ZonedDateTime.now()
 
-  val releasedToExternalBeta = LiveAppBeta("12349", now, "IN_BETA_TESTING", "IN_BETA_TESTING")
-  val unreleasedToExternalBeta = LiveAppBeta("22349", now, "IN_BETA_TESTING", "IN_REVIEW")
+  val releasedToExternalBeta = LiveAppBeta("12349", "id123", now, "IN_BETA_TESTING", "IN_BETA_TESTING")
+  val unreleasedToExternalBeta = LiveAppBeta("22349", "id223", now, "IN_BETA_TESTING", "IN_REVIEW")
 
   test("findLatestBuildsWithExternalTesters should correctly identify the 4 most recent beta versions from Apple's response") {
 


### PR DESCRIPTION
This adds functionality for automatically submitting beta builds for review and distributing them to external testers. 

Follow up to:
https://github.com/guardian/ios-live/pull/5150
https://github.com/guardian/live-app-versions/pull/12
https://github.com/guardian/live-app-versions/pull/14

There will be a final PR after this one to schedule the new lambda regularly and add monitoring/alerting. For now it's been tested by manually re-running the lambda at various points of the deployment cycle.