### PR TITLE
Trigger the deployments lambda on a schedule

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -101,10 +101,10 @@ Resources:
       Runtime: java8
       Timeout: 60
 
-  Lambda:
+  LiveAppVersionsLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub live-app-versions-${Stage}
+      FunctionName: !Sub live-app-versions-v2-${Stage}
       Code:
         S3Bucket:
           Ref: DeployBucket
@@ -129,14 +129,14 @@ Resources:
       Description: Triggers the lambda periodically, allowing us to check whether a new version has been released
       ScheduleExpression: rate(5 minutes)
       Targets:
-        - Id: Lambda
-          Arn: !GetAtt Lambda.Arn
+        - Id: LiveAppVersionsLambda
+          Arn: !GetAtt LiveAppVersionsLambda.Arn
 
   PollingEventLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !GetAtt Lambda.Arn
+      FunctionName: !GetAtt LiveAppVersionsLambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt PollingEvent.Arn
 
@@ -166,7 +166,7 @@ Resources:
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref Lambda
+                  Value: !Ref LiveAppVersionsLambda
             Period: 3600
             Stat: Sum
           ReturnData: false
@@ -178,7 +178,7 @@ Resources:
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref Lambda
+                  Value: !Ref LiveAppVersionsLambda
             Period: 3600
             Stat: Sum
           ReturnData: false

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -126,17 +126,27 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       State: !FindInMap [StageVariables, !Ref Stage, ScheduleStatus]
-      Description: Triggers the lambda periodically, allowing us to check whether a new version has been released
+      Description: Triggers the lambdas in this project periodically to check for new deployments or completed releases
       ScheduleExpression: rate(5 minutes)
       Targets:
         - Id: LiveAppVersionsLambda
           Arn: !GetAtt LiveAppVersionsLambda.Arn
+        - Id: IosDeploymentsLambda
+          Arn: !GetAtt IosDeploymentsLambda.Arn
 
-  PollingEventLambdaPermission:
+  PollingEventLiveAppVersionsLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt LiveAppVersionsLambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt PollingEvent.Arn
+
+  PollingEventIosDeploymentsLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt IosDeploymentsLambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt PollingEvent.Arn
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     type: aws-lambda
     parameters:
       bucket: mobile-dist
-      functionNames: [live-app-versions-, ios-deployments-]
+      functionNames: [live-app-versions-v2-, ios-deployments-]
       fileName: live-app-versions.jar
       prefixStack: false
     dependencies: [live-app-versions-cfn]


### PR DESCRIPTION
Now that the new deployments lambda is [functionally complete](https://github.com/guardian/live-app-versions/pull/15), we want it to poll automatically.