### PR TITLE
Refactor to add basic Android versions lambda

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -101,10 +101,10 @@ Resources:
       Runtime: java8
       Timeout: 60
 
-  LiveAppVersionsLambda:
+  IosLiveAppVersionsLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub live-app-versions-${Stage}
+      FunctionName: !Sub ios-live-app-versions-${Stage}
       Code:
         S3Bucket:
           Ref: DeployBucket
@@ -116,7 +116,27 @@ Resources:
           App: !Ref App
           APPLE_APP_ID: !Ref AppleAppId
       Description: Lambda function which retrieves the latest beta version from App Store Connect.
-      Handler: com.gu.liveappversions.Lambda::handler
+      Handler: com.gu.liveappversions.ios.Lambda::handler
+      MemorySize: 1024
+      Role: !GetAtt ExecutionRole.Arn
+      Runtime: java8
+      Timeout: 60
+
+  AndroidLiveAppVersionsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub android-live-app-versions-${Stage}
+      Code:
+        S3Bucket:
+          Ref: DeployBucket
+        S3Key: !Sub ${Stack}/${Stage}/${App}/${App}.jar
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Stack: !Ref Stack
+          App: !Ref App
+      Description: Lambda function which retrieves the latest version/track information from Google Play.
+      Handler: com.gu.liveappversions.android.Lambda::handler
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
@@ -129,16 +149,26 @@ Resources:
       Description: Triggers the lambdas in this project periodically to check for new deployments or completed releases
       ScheduleExpression: rate(5 minutes)
       Targets:
-        - Id: LiveAppVersionsLambda
-          Arn: !GetAtt LiveAppVersionsLambda.Arn
+        - Id: IosLiveAppVersionsLambda
+          Arn: !GetAtt IosLiveAppVersionsLambda.Arn
+        - Id: AndroidLiveAppVersionsLambda
+          Arn: !GetAtt AndroidLiveAppVersionsLambda.Arn
         - Id: IosDeploymentsLambda
           Arn: !GetAtt IosDeploymentsLambda.Arn
 
-  PollingEventLiveAppVersionsLambdaPermission:
+  PollingEventIosLiveAppVersionsLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !GetAtt LiveAppVersionsLambda.Arn
+      FunctionName: !GetAtt IosLiveAppVersionsLambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt PollingEvent.Arn
+
+  PollingEventAndroidLiveAppVersionsLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt AndroidLiveAppVersionsLambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt PollingEvent.Arn
 
@@ -150,7 +180,7 @@ Resources:
       Principal: events.amazonaws.com
       SourceArn: !GetAtt PollingEvent.Arn
 
-  LiveAppVersionsFailureAlarm:
+  IosLiveAppVersionsFailureAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
@@ -173,7 +203,7 @@ Resources:
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref LiveAppVersionsLambda
+                  Value: !Ref IosLiveAppVersionsLambda
             Period: 3600
             Stat: Sum
           ReturnData: false
@@ -185,7 +215,48 @@ Resources:
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref LiveAppVersionsLambda
+                  Value: !Ref IosLiveAppVersionsLambda
+            Period: 3600
+            Stat: Sum
+          ReturnData: false
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Threshold: 100
+
+  AndroidLiveAppVersionsFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: !FindInMap [StageVariables, !Ref Stage, AlarmActionsEnabled]
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
+      OKActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
+      AlarmName: !Sub Failures when retrieving or storing the latest Android versions in ${Stage}
+      Metrics:
+        - Id: e1
+          Label: Error percentage of lambda
+          Expression: "100*(m1/m2)"
+        - Id: m1
+          Label: Number of errors for lambda
+          MetricStat:
+            Metric:
+              MetricName: Errors
+              Namespace: AWS/Lambda
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref AndroidLiveAppVersionsLambda
+            Period: 3600
+            Stat: Sum
+          ReturnData: false
+        - Id: m2
+          Label: Number of invocations for lambda
+          MetricStat:
+            Metric:
+              MetricName: Invocations
+              Namespace: AWS/Lambda
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref AndroidLiveAppVersionsLambda
             Period: 3600
             Stat: Sum
           ReturnData: false

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -188,7 +188,7 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
       OKActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:mobile-server-side
-      AlarmName: !Sub Failures when retrieving or storing the latest iOS beta version in ${Stage}
+      AlarmName: !Sub Failures when retrieving or storing the latest iOS versions in ${Stage}
       AlarmDescription: |
         <<<Runbook|https://docs.google.com/document/d/1by6RLfo_d-6wyAp7OoQquv4tZYUR6FYhAn0GZkJtqH8/edit#heading=h.f2qd026kxlds>>>
       Metrics:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     type: aws-lambda
     parameters:
       bucket: mobile-dist
-      functionNames: [live-app-versions-, ios-deployments-]
+      functionNames: [android-live-app-versions-, ios-live-app-versions-, ios-deployments-]
       fileName: live-app-versions.jar
       prefixStack: false
     dependencies: [live-app-versions-cfn]

--- a/src/main/scala/com/gu/liveappversions/S3Uploader.scala
+++ b/src/main/scala/com/gu/liveappversions/S3Uploader.scala
@@ -6,7 +6,8 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.{ CannedAccessControlList, ObjectMetadata, PutObjectRequest, PutObjectResult }
 import com.gu.config.Aws
 import com.gu.config.Config.Env
-import com.gu.liveappversions.Lambda.logger
+import com.gu.liveappversions.ios.BuildOutput
+import com.gu.liveappversions.ios.Lambda.logger
 import io.circe.syntax._
 
 import scala.util.{ Failure, Success, Try }

--- a/src/main/scala/com/gu/liveappversions/android/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/android/Lambda.scala
@@ -1,0 +1,15 @@
+package com.gu.liveappversions.android
+
+import com.gu.config.Config.Env
+import org.slf4j.{ Logger, LoggerFactory }
+
+object Lambda {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def handler(): Unit = {
+    val env = Env()
+    logger.info(s"Starting $env")
+  }
+
+}

--- a/src/main/scala/com/gu/liveappversions/ios/BuildOutput.scala
+++ b/src/main/scala/com/gu/liveappversions/ios/BuildOutput.scala
@@ -1,9 +1,9 @@
-package com.gu.liveappversions
+package com.gu.liveappversions.ios
 
 import com.gu.appstoreconnectapi.Conversion.LiveAppBeta
-import com.gu.liveappversions.Lambda.logger
+import com.gu.liveappversions.ios.Lambda.logger
 import io.circe.generic.semiauto.deriveEncoder
-import io.circe.{ Encoder, HCursor, Json }
+import io.circe.{ Encoder, Json }
 
 import scala.util.{ Failure, Success, Try }
 

--- a/src/main/scala/com/gu/liveappversions/ios/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/ios/Lambda.scala
@@ -1,8 +1,9 @@
-package com.gu.liveappversions
+package com.gu.liveappversions.ios
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.appstoreconnectapi.{ AppStoreConnectApi, JwtTokenBuilder }
 import com.gu.config.Config.{ AppStoreConnectConfig, Env }
+import com.gu.liveappversions.S3Uploader
 import org.slf4j.{ Logger, LoggerFactory }
 
 import scala.util.{ Failure, Success }

--- a/src/test/scala/com.gu.liveappversions.integration/IntegrationTest.scala
+++ b/src/test/scala/com.gu.liveappversions.integration/IntegrationTest.scala
@@ -1,7 +1,7 @@
 package com.gu.liveappversions.integration
 
 import com.gu.config.Config.Env
-import com.gu.liveappversions.Lambda
+import com.gu.liveappversions.ios.Lambda
 
 object IntegrationTest {
 

--- a/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
+++ b/src/test/scala/com/gu/liveappversions/BuildOutputTest.scala
@@ -3,6 +3,7 @@ package com.gu.liveappversions
 import java.time.ZonedDateTime
 
 import com.gu.appstoreconnectapi.Conversion.LiveAppBeta
+import com.gu.liveappversions.ios.BuildOutput
 import org.scalatest.FunSuite
 
 class BuildOutputTest extends FunSuite {


### PR DESCRIPTION
## What does this change?

* Adds infrastructure for a new lambda function (in support of [this ticket](https://theguardian.atlassian.net/browse/LIVE-422)). Currently this lambda's code doesn't do anything useful; I'll add the logic in a separate PR.
* Moves some iOS-specific code to accommodate the new Android lambda

## How to test

I've confirmed that this can be [deployed via RiffRaff](https://riffraff.gutools.co.uk/deployment/view/abdb32c7-4a1f-4827-9aa5-aa2467a31a2a). I've also double checked the lambda and alarm configuration via AWS.

## How can we measure success?

* Original iOS lambdas should continue working as before - I'll be able to check this shortly after deployment as both lambdas are triggered on a regular schedule.
* New infrastructure should be deployed successfully.

## Have we considered potential risks?

* Failure alarm has been configured for the new lambda.