### PR TITLE
Add basic functionality for checking Android versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.1", // Pin a more recent version to avoid Snyk vulnerabilities introduced by s3 sdk
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "com.google.auth" % "google-auth-library-oauth2-http" % "0.20.0",
   "com.gu" %% "simple-configuration-ssm" % "1.4.1",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.8.2",
   "com.pauldijou" %% "jwt-core" % "4.2.0",

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -51,6 +51,19 @@ object Config {
     }
   }
 
+  case class GoogleServiceAccount(json: String)
+
+  object GoogleServiceAccount {
+
+    def apply(env: Env): GoogleServiceAccount = {
+      val ssmPrivateConfig = ConfigurationLoader.load(setupAppIdentity(env), Aws.credentials("mobile")) {
+        case identity: AwsIdentity => SSMConfigurationLocation.default(identity)
+      }
+      GoogleServiceAccount(ssmPrivateConfig.getString("google.serviceAccountJson"))
+    }
+
+  }
+
   case class ExternalTesterGroup(id: String, name: String)
   case class ExternalTesterConfig(group1: ExternalTesterGroup, group2: ExternalTesterGroup)
   val externalTesterConfigForProd = ExternalTesterConfig(

--- a/src/main/scala/com/gu/liveappversions/android/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/android/Lambda.scala
@@ -1,6 +1,8 @@
 package com.gu.liveappversions.android
 
 import com.gu.config.Config.Env
+import com.gu.playdeveloperapi.PlayDeveloperApi.PlayDeveloperApi
+import com.gu.playdeveloperapi.Token
 import org.slf4j.{ Logger, LoggerFactory }
 
 object Lambda {
@@ -10,6 +12,17 @@ object Lambda {
   def handler(): Unit = {
     val env = Env()
     logger.info(s"Starting $env")
+    for {
+      token <- Token.getToken(env)
+      tracks <- PlayDeveloperApi.getTrackInfo(token)
+    } yield {
+      logger.info(s"Retrieved track info: $tracks")
+    }
+
   }
 
+}
+
+object Test extends App {
+  Lambda.handler()
 }

--- a/src/main/scala/com/gu/liveappversions/android/Lambda.scala
+++ b/src/main/scala/com/gu/liveappversions/android/Lambda.scala
@@ -14,9 +14,9 @@ object Lambda {
     logger.info(s"Starting $env")
     for {
       token <- Token.getToken(env)
-      tracks <- PlayDeveloperApi.getTrackInfo(token)
+      versions <- PlayDeveloperApi.getBetaAndProductionVersions(token)
     } yield {
-      logger.info(s"Retrieved track info: $tracks")
+      logger.info(s"Retrieved version info: $versions")
     }
 
   }

--- a/src/main/scala/com/gu/playdeveloperapi/Conversion.scala
+++ b/src/main/scala/com/gu/playdeveloperapi/Conversion.scala
@@ -1,0 +1,37 @@
+package com.gu.playdeveloperapi
+
+import com.gu.playdeveloperapi.PlayDeveloperApi.PlayDeveloperApi.{ Track, TracksResponse }
+
+import scala.util.{ Failure, Success, Try }
+
+object Conversion {
+
+  case class Build(versionName: String)
+  case class AndroidLiveAppVersions(currentBeta: Build, currentProduction: Build)
+
+  case object PlayDeveloperApiConversionException extends Throwable
+
+  def searchForTrack(allTracks: List[Track], trackName: String): Option[Build] = {
+    allTracks
+      .find(_.track == trackName)
+      .map(track => track.releases)
+      .flatMap(_.find(_.status == "completed"))
+      .map(build => Build(build.name))
+  }
+
+  def toAndroidLiveAppVersions(tracksResponse: TracksResponse): Try[AndroidLiveAppVersions] = {
+
+    val allTracks = tracksResponse.tracks
+
+    val searchForBeta: Option[Build] = searchForTrack(allTracks, "beta")
+    val searchForProduction: Option[Build] = searchForTrack(allTracks, "production")
+
+    (searchForBeta, searchForProduction) match {
+      case (Some(beta), Some(production)) => Success(
+        AndroidLiveAppVersions(currentBeta = beta, currentProduction = production))
+      case _ => Failure(PlayDeveloperApiConversionException)
+    }
+
+  }
+
+}

--- a/src/main/scala/com/gu/playdeveloperapi/PlayDeveloperApi.scala
+++ b/src/main/scala/com/gu/playdeveloperapi/PlayDeveloperApi.scala
@@ -2,6 +2,7 @@ package com.gu.playdeveloperapi
 
 import com.google.auth.oauth2.AccessToken
 import com.gu.okhttp.SharedClient
+import com.gu.playdeveloperapi.Conversion.AndroidLiveAppVersions
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import io.circe.parser._
@@ -47,18 +48,19 @@ object PlayDeveloperApi {
 
     }
 
-    def getTrackInfo(accessToken: AccessToken): Try[String] = {
+    def getBetaAndProductionVersions(accessToken: AccessToken): Try[AndroidLiveAppVersions] = {
       for {
         edit <- createEdit(accessToken)
         trackResponse <- listTrackInfo(accessToken, edit)
+        versions <- Conversion.toAndroidLiveAppVersions(trackResponse)
       } yield {
-        trackResponse.tracks.find(_.track == "production").toString
+        versions
       }
     }
 
     case class EditId(id: String)
 
-    case class Release(name: String)
+    case class Release(name: String, status: String)
     case class Track(track: String, releases: List[Release])
     case class TracksResponse(tracks: List[Track])
 

--- a/src/main/scala/com/gu/playdeveloperapi/PlayDeveloperApi.scala
+++ b/src/main/scala/com/gu/playdeveloperapi/PlayDeveloperApi.scala
@@ -1,0 +1,67 @@
+package com.gu.playdeveloperapi
+
+import com.google.auth.oauth2.AccessToken
+import com.gu.okhttp.SharedClient
+import io.circe.generic.auto._
+import io.circe.parser.decode
+import io.circe.parser._
+import okhttp3.{ Request, RequestBody }
+
+import scala.util.Try
+
+object PlayDeveloperApi {
+
+  object PlayDeveloperApi {
+
+    val baseUrl = "https://www.googleapis.com/androidpublisher/v3/applications/com.guardian/edits"
+
+    private def createEdit(accessToken: AccessToken): Try[EditId] = {
+
+      val request = new Request.Builder()
+        .url(baseUrl)
+        .addHeader("Authorization", s"Bearer ${accessToken.getTokenValue}")
+        .post(RequestBody.create("", null))
+        .build()
+
+      for {
+        httpResponse <- Try(SharedClient.client.newCall(request).execute)
+        bodyAsString <- SharedClient.getResponseBodyIfSuccessful("Google Play Developer API", httpResponse)
+        editId <- decode[EditId](bodyAsString).toTry
+      } yield editId
+
+    }
+
+    private def listTrackInfo(accessToken: AccessToken, openEdit: EditId): Try[TracksResponse] = {
+
+      val request = new Request.Builder()
+        .url(s"$baseUrl/${openEdit.id}/tracks")
+        .addHeader("Authorization", s"Bearer ${accessToken.getTokenValue}")
+        .get()
+        .build()
+
+      for {
+        httpResponse <- Try(SharedClient.client.newCall(request).execute)
+        bodyAsString <- SharedClient.getResponseBodyIfSuccessful("Google Play Developer API", httpResponse)
+        tracksResponse <- decode[TracksResponse](bodyAsString).toTry
+      } yield tracksResponse
+
+    }
+
+    def getTrackInfo(accessToken: AccessToken): Try[String] = {
+      for {
+        edit <- createEdit(accessToken)
+        trackResponse <- listTrackInfo(accessToken, edit)
+      } yield {
+        trackResponse.tracks.find(_.track == "production").toString
+      }
+    }
+
+    case class EditId(id: String)
+
+    case class Release(name: String)
+    case class Track(track: String, releases: List[Release])
+    case class TracksResponse(tracks: List[Track])
+
+  }
+
+}

--- a/src/main/scala/com/gu/playdeveloperapi/Token.scala
+++ b/src/main/scala/com/gu/playdeveloperapi/Token.scala
@@ -1,0 +1,21 @@
+package com.gu.playdeveloperapi
+
+import java.io.ByteArrayInputStream
+
+import com.google.auth.oauth2.{ AccessToken, GoogleCredentials }
+import com.gu.config.Config.{ Env, GoogleServiceAccount }
+
+import scala.util.Try
+
+object Token {
+
+  def getToken(env: Env): Try[AccessToken] = Try {
+    val credentials = GoogleCredentials
+      .fromStream(new ByteArrayInputStream(GoogleServiceAccount(env).json.getBytes))
+      .createScoped("https://www.googleapis.com/auth/androidpublisher")
+    credentials.refresh()
+    credentials.getAccessToken
+  }
+
+}
+

--- a/src/test/scala/com/gu/playdeveloperapi/ConversionTest.scala
+++ b/src/test/scala/com/gu/playdeveloperapi/ConversionTest.scala
@@ -1,0 +1,23 @@
+package com.gu.playdeveloperapi
+
+import com.gu.playdeveloperapi.Conversion.Build
+import com.gu.playdeveloperapi.PlayDeveloperApi.PlayDeveloperApi.{ Release, Track }
+import org.scalatest.FunSuite
+
+class ConversionTest extends FunSuite {
+
+  val betaTrack = Track("beta", releases = List(Release("1.2.123", "completed")))
+  val productionTrack = Track("production", releases = List(Release("1.2.123", "completed")))
+  val productionTrackWithDraft = Track("production", releases = List(Release("1.2.123", "draft")))
+
+  test("searchForTrack correctly identifies a beta build") {
+    val result = Conversion.searchForTrack(List(betaTrack, productionTrack), "beta")
+    assert(result == Some(Build("1.2.123")))
+  }
+
+  test("searchForTrack correctly ignores a draft production build") {
+    val result = Conversion.searchForTrack(List(betaTrack, productionTrackWithDraft), "production")
+    assert(result == None)
+  }
+
+}


### PR DESCRIPTION
## What does this change?

Following on from https://github.com/guardian/live-app-versions/pull/20, this PR adds basic functionality for retrieving version/track information from Google. At the moment the lambda doesn't store the data anywhere useful (it simply logs the result) - I'll add the data storing step in the next PR.

## How to test

Once deployed to `PROD`, we should see the latest Android build information appearing in the logs.