### PR TITLE
Include information about newer lambdas in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,22 @@
 # live-app-versions
 
+### android-live-app-versions
+
+Retrieves information about releases of the [Android Live App](https://github.com/guardian/android-news-app) from the [Play Developer API](https://developers.google.com/android-publisher#publishing).
+
+### ios-live-app-versions
+
 Retrieves information about beta releases of the [iOS Live App](https://github.com/guardian/ios-live) from the 
 [App Store Connect API](https://developer.apple.com/app-store-connect/api/) and stores the results in S3.
 
-## Example Response
+### ios-deployments
 
-Note that this response only ever includes beta builds which have been released to external testers:
-
-```
-{
-   "latestReleasedBuild" : {
-     "version" : "17672"
-   },
-   "previouslyReleasedBuilds" : [
-     {
-       "version" : "17667"
-     },
-     {
-       "version" : "17661"
-     },
-     {
-       "version" : "17657"
-     }
-   ]
- }
-```
+Distributes releases of the [iOS Live App](https://github.com/guardian/ios-live) to external beta testers and provides an audit trail of releases via [GitHub deployments](https://developer.github.com/v3/repos/deployments/#deployments).
 
 ## Infrastructure
 
-The project is implemented in Scala as an AWS lambda. It runs on a regular schedule and stores results in an S3 bucket which sits behind Fastly. 
+The project is implemented in Scala as a collection of AWS Lambdas. The lambdas run on a regular schedule; results are stored in an S3 bucket which sits behind Fastly. 
 
 The infrastructure for serving JSON via S3 and Fastly is shared with [`mobile-static`](https://github.com/guardian/mobile-static#infrastructure).
 
-You can view the latest beta builds via https://mobile.guardianapis.com/static/reserved-paths/ios-live-app/recent-beta-releases.json.
+You can view the latest iOS beta builds via https://mobile.guardianapis.com/static/reserved-paths/ios-live-app/recent-beta-releases.json.


### PR DESCRIPTION
I noticed that the README for this project was quite out of date.