### PR TITLE
[iosdeployments] Add functionality for tracking new production releases

### DIFF
--- a/src/main/scala/com/gu/githubapi/GitHubApi.scala
+++ b/src/main/scala/com/gu/githubapi/GitHubApi.scala
@@ -44,7 +44,7 @@ object GitHubApi {
     val query =
       """
     |{
-    |	"query": "query { repository(owner:\"guardian\", name:\"ios-live\") { deployments(last: 3) { edges { node { databaseId, createdAt, environment, state, payload, latestStatus { createdAt, description  } } } } } }"
+    |	"query": "query { repository(owner:\"guardian\", name:\"ios-live\") { deployments(last: 10) { edges { node { databaseId, createdAt, environment, state, payload, latestStatus { createdAt, description  } } } } } }"
     |}
     |""".stripMargin
     for {

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -2,13 +2,14 @@ package com.gu.iosdeployments
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.appstoreconnectapi.Conversion.LiveAppBeta
-import com.gu.appstoreconnectapi.{ AppStoreConnectApi, JwtTokenBuilder }
+import com.gu.appstoreconnectapi.{AppStoreConnectApi, JwtTokenBuilder}
 import com.gu.config.Config
-import com.gu.config.Config.{ AppStoreConnectConfig, Env, GitHubConfig }
+import com.gu.config.Config.{AppStoreConnectConfig, Env, GitHubConfig}
+import com.gu.githubapi.Conversion.RunningLiveAppDeployment
 import com.gu.githubapi.GitHubApi
-import org.slf4j.{ Logger, LoggerFactory }
+import org.slf4j.{Logger, LoggerFactory}
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 object Lambda {
 
@@ -20,42 +21,55 @@ object Lambda {
     process(env)
   }
 
+  def handleBetaDeployment(env: Env, maybeDeployment: Option[RunningLiveAppDeployment], latestBetas: List[LiveAppBeta], appStoreConnectToken: String, gitHubConfig: GitHubConfig): Try[Unit] = {
+
+    val externalTesterConfig = if (env.stage == "PROD") {
+      Config.externalTesterConfigForProd
+    } else {
+      Config.externalTesterConfigForTesting
+    }
+
+    maybeDeployment match {
+      case Some(runningDeployment) =>
+        val attemptToFindBeta = latestBetas.find(_.version == runningDeployment.version)
+        (runningDeployment.environment, attemptToFindBeta) match {
+          case ("internal-beta", Some(LiveAppBeta(_, _, _, "IN_BETA_TESTING", _))) =>
+            logger.info(s"Internal beta deployment for ${runningDeployment.version} is complete...")
+            GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)
+          case ("external-beta", Some(LiveAppBeta(_, _, _, _, "IN_BETA_TESTING"))) =>
+            logger.info(s"External beta deployment for ${runningDeployment.version} is complete...")
+            GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)
+          case ("external-beta", Some(build@LiveAppBeta(_, _, _, "IN_BETA_TESTING", "READY_FOR_BETA_SUBMISSION"))) =>
+            logger.info(s"External beta deployment for ${runningDeployment.version} can now be submitted for review...")
+            AppStoreConnectApi.submitForBetaTesting(appStoreConnectToken, build.buildId)
+          case ("external-beta", Some(build@LiveAppBeta(_, _, _, _, "BETA_APPROVED"))) =>
+            logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
+            AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig)
+          case (_, None) =>
+            Try(logger.info(s"Found running deployment ${runningDeployment.version}, but build was not present in App Store Connect response"))
+          case _ =>
+            Try(logger.info(s"No action was required for ${runningDeployment.version}. Full details are: $attemptToFindBeta"))
+        }
+      case None =>
+        Try(logger.info("No running deployments found."))
+    }
+  }
+
+
   def process(env: Env): Unit = {
     logger.info("Loading configuration...")
     val appStoreConnectConfig = AppStoreConnectConfig(env)
     val appStoreConnectToken = JwtTokenBuilder.buildToken(appStoreConnectConfig)
     val gitHubConfig = GitHubConfig(env)
-    val externalTesterConfig = if (env.stage == "PROD") { Config.externalTesterConfigForProd } else { Config.externalTesterConfigForTesting }
     logger.info("Successfully loaded configuration...")
     val result = for {
       runningDeployments <- GitHubApi.getRunningDeployments(gitHubConfig)
       appStoreConnectBetaBuilds <- AppStoreConnectApi.getLatestBetaBuilds(appStoreConnectToken, appStoreConnectConfig)
-    } yield {
       // Process one running deployment per lambda execution
       // In practice it's extremely unlikely that there will be two concurrent deployments anyway
-      runningDeployments.headOption match {
-        case Some(runningDeployment) =>
-          val attemptToFindBeta = appStoreConnectBetaBuilds.find(_.version == runningDeployment.version)
-          (runningDeployment.environment, attemptToFindBeta) match {
-            case ("internal-beta", Some(LiveAppBeta(_, _, _, "IN_BETA_TESTING", _))) =>
-              logger.info(s"Internal beta deployment for ${runningDeployment.version} is complete...")
-              GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment).get
-            case ("external-beta", Some(LiveAppBeta(_, _, _, _, "IN_BETA_TESTING"))) =>
-              logger.info(s"External beta deployment for ${runningDeployment.version} is complete...")
-              GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment).get
-            case ("external-beta", Some(build @ LiveAppBeta(_, _, _, "IN_BETA_TESTING", "READY_FOR_BETA_SUBMISSION"))) =>
-              logger.info(s"External beta deployment for ${runningDeployment.version} can now be submitted for review...")
-              AppStoreConnectApi.submitForBetaTesting(appStoreConnectToken, build.buildId).get
-            case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "BETA_APPROVED"))) =>
-              logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
-              AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig).get
-            case (_, None) =>
-              logger.info(s"Found running deployment ${runningDeployment.version}, but build was not present in App Store Connect response")
-            case _ =>
-              logger.info(s"No action was required for ${runningDeployment.version}. Full details are: $attemptToFindBeta")
-          }
-        case None => logger.info("No running deployments found.")
-      }
+      handleBeta <- handleBetaDeployment(env, runningDeployments.headOption, appStoreConnectBetaBuilds, appStoreConnectToken, gitHubConfig)
+    } yield {
+      handleBeta
     }
 
     result match {

--- a/src/test/scala/com/gu/appstoreconnectapi/ConversionTest.scala
+++ b/src/test/scala/com/gu/appstoreconnectapi/ConversionTest.scala
@@ -28,7 +28,7 @@ class ConversionTest extends FunSuite {
 
   test("combineModels should produce a list of LiveAppBetas from a valid App Store Connect response") {
     val buildsResponse = BuildsResponse(allBuildDetails, allBetaBuildDetails)
-    val result = Conversion.combineModels(buildsResponse)
+    val result = Conversion.combineBuildsResponseModels(buildsResponse)
     val expectedResults = List(
       LiveAppBeta("12345", "id123", now, "INTERNAL", "EXTERNAL"),
       LiveAppBeta("12344", "id124", now, "INTERNAL", "EXTERNAL"),
@@ -40,13 +40,13 @@ class ConversionTest extends FunSuite {
 
   test("combineModels should fail if there are objects missing from the App Store Connect response") {
     val buildsResponse = BuildsResponse(allBuildDetails.drop(1), allBetaBuildDetails)
-    val result = Conversion.combineModels(buildsResponse)
+    val result = Conversion.combineBuildsResponseModels(buildsResponse)
     assert(result.isFailure)
   }
 
   test("combineModels should fail if the ids in the App Store Connect response do not match") {
     val buildsResponse = BuildsResponse(List(buildDetails), List(betaBuildDetails.copy(id = "fakeId")))
-    val result = Conversion.combineModels(buildsResponse)
+    val result = Conversion.combineBuildsResponseModels(buildsResponse)
     assert(result.isFailure)
   }
 


### PR DESCRIPTION
This allows us to keep a record of production releases [in GitHub](https://github.com/guardian/ios-live/deployments/activity_log) (I've tested this with `8.37` to confirm that it works).

There's a bit more detail on the motivation for this change here: https://github.com/guardian/ios-live/pull/5326 (tl;dr Apple don't provide the webhooks that we need).