### PR TITLE
Handle rejected builds gracefully

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -54,7 +54,7 @@ object AppStoreConnectApi {
   }
 
   def getLatestProductionBuilds(token: String, appStoreConnectConfig: AppStoreConnectConfig): Try[List[LiveAppProduction]] = {
-    val buildsQuery = s"/apps/${appStoreConnectConfig.appleAppId}/appStoreVersions?limit=20&sort=-version&include=build"
+    val buildsQuery = s"/apps/${appStoreConnectConfig.appleAppId}/appStoreVersions?limit=20&include=build"
     val request = new Request.Builder()
       .url(s"$appStoreConnectBaseUrl$buildsQuery")
       .addHeader("Authorization", s"Bearer $token")

--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -66,10 +66,10 @@ object AppStoreConnectApi {
       httpResponse <- Try(SharedClient.client.newCall(request).execute)
       bodyAsString <- SharedClient.getResponseBodyIfSuccessful("App Store Connect API", httpResponse)
       appStoreVersionsResponse <- decode[AppStoreVersionsResponse](bodyAsString).toTry
-      latestProductionRelease <- combineAppStoreVersionsResponseModels(appStoreVersionsResponse)
+      latestProductionReleases <- combineAppStoreVersionsResponseModels(appStoreVersionsResponse)
     } yield {
-      logger.info(s"The latest production release is: $latestProductionRelease")
-      latestProductionRelease
+      logger.info(s"The latest production releases are: $latestProductionReleases")
+      latestProductionReleases
     }
   }
 

--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -34,7 +34,7 @@ object AppStoreConnectApi {
   case class BetaBuildDetails(id: String, attributes: BetaBuildAttributes)
   case class BuildsResponse(data: List[BuildDetails], included: List[BetaBuildDetails])
   case class AppStoreVersionAttributes(versionString: String, appStoreState: String)
-  case class AppStoreVersion(attributes: AppStoreVersionAttributes)
+  case class AppStoreVersion(id: String, attributes: AppStoreVersionAttributes)
   case class AppStoreVersionsResponse(data: List[AppStoreVersion], included: List[BuildDetails])
 
   val appStoreConnectBaseUrl = "https://api.appstoreconnect.apple.com/v1"
@@ -53,8 +53,8 @@ object AppStoreConnectApi {
     } yield liveAppBetas
   }
 
-  def getLatestProductionBuild(token: String, appStoreConnectConfig: AppStoreConnectConfig): Try[LiveAppProduction] = {
-    val buildsQuery = s"/apps/${appStoreConnectConfig.appleAppId}/appStoreVersions?filter[appStoreState]=READY_FOR_SALE&include=build"
+  def getLatestProductionBuilds(token: String, appStoreConnectConfig: AppStoreConnectConfig): Try[List[LiveAppProduction]] = {
+    val buildsQuery = s"/apps/${appStoreConnectConfig.appleAppId}/appStoreVersions?limit=20&sort=-version&include=build"
     val request = new Request.Builder()
       .url(s"$appStoreConnectBaseUrl$buildsQuery")
       .addHeader("Authorization", s"Bearer $token")

--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -57,7 +57,7 @@ object AppStoreConnectApi {
   }
 
   def getLatestProductionBuilds(token: String, appStoreConnectConfig: AppStoreConnectConfig): Try[List[LiveAppProduction]] = {
-    val buildsQuery = s"/apps/${appStoreConnectConfig.appleAppId}/appStoreVersions?limit=20&include=build"
+    val buildsQuery = s"/apps/${appStoreConnectConfig.appleAppId}/appStoreVersions?limit=5&include=build"
     val request = new Request.Builder()
       .url(s"$appStoreConnectBaseUrl$buildsQuery")
       .addHeader("Authorization", s"Bearer $token")

--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -33,8 +33,11 @@ object AppStoreConnectApi {
   case class BetaBuildAttributes(internalBuildState: String, externalBuildState: String)
   case class BetaBuildDetails(id: String, attributes: BetaBuildAttributes)
   case class BuildsResponse(data: List[BuildDetails], included: List[BetaBuildDetails])
+  case class AppStoreVersionsBuildData(id: String)
+  case class AppStoreVersionsBuild(data: Option[AppStoreVersionsBuildData])
+  case class AppStoreVersionRelationships(build: AppStoreVersionsBuild)
   case class AppStoreVersionAttributes(versionString: String, appStoreState: String)
-  case class AppStoreVersion(id: String, attributes: AppStoreVersionAttributes)
+  case class AppStoreVersion(id: String, attributes: AppStoreVersionAttributes, relationships: AppStoreVersionRelationships)
   case class AppStoreVersionsResponse(data: List[AppStoreVersion], included: List[BuildDetails])
 
   val appStoreConnectBaseUrl = "https://api.appstoreconnect.apple.com/v1"

--- a/src/main/scala/com/gu/githubapi/GitHubApi.scala
+++ b/src/main/scala/com/gu/githubapi/GitHubApi.scala
@@ -57,14 +57,22 @@ object GitHubApi {
   }
 
   def markDeploymentAsSuccess(gitHubConfig: GitHubConfig, deployment: RunningLiveAppDeployment): Try[Unit] = {
+    markDeploymentAsFinished(gitHubConfig, deployment, "success")
+  }
+
+  def markDeploymentAsFailure(gitHubConfig: GitHubConfig, deployment: RunningLiveAppDeployment): Try[Unit] = {
+    markDeploymentAsFinished(gitHubConfig, deployment, "failure")
+  }
+
+  def markDeploymentAsFinished(gitHubConfig: GitHubConfig, deployment: RunningLiveAppDeployment, finishedState: String): Try[Unit] = {
     val url = s"$restApiUrl/repos/guardian/ios-live/deployments/${deployment.gitHubDatabaseId.toString}/statuses"
     val body =
       s"""
-        |{
-        |  "state": "success",
-        |  "description": "${deployment.version}"
-        |}
-        |""".stripMargin
+         |{
+         |  "state": "$finishedState",
+         |  "description": "${deployment.version}"
+         |}
+         |""".stripMargin
     for {
       httpResponse <- Try(SharedClient.client.newCall(gitHubPostRequest(url, body, gitHubConfig)).execute)
       _ <- SharedClient.getResponseBodyIfSuccessful("GitHub API", httpResponse)


### PR DESCRIPTION
In the following scenario:

1. We submit build A for review
1. We/Apple decide to reject build A
1. We submit build B for review 
1. We release build B

...post-release automation was not being started correctly for build B. This happened because the polling logic was still waiting for build A to become released before moving onto checking build B.

This PR fixes the issue described above by marking the deployment linked to a rejected build as `failed` in [GitHub](https://github.com/guardian/ios-live/deployments/activity_log?environment=production). I've tested this by uploading and rejecting a build.