### PR TITLE
Handle abandoned iOS deployments

### DIFF
--- a/src/main/scala/com/gu/githubapi/Conversion.scala
+++ b/src/main/scala/com/gu/githubapi/Conversion.scala
@@ -1,15 +1,17 @@
 package com.gu.githubapi
 
+import java.time.ZonedDateTime
+
 import com.gu.githubapi.GitHubApi.Deployment
 
 object Conversion {
 
-  case class RunningLiveAppDeployment(version: String, environment: String, gitHubDatabaseId: Int)
+  case class RunningLiveAppDeployment(version: String, environment: String, gitHubDatabaseId: Int, createdAt: ZonedDateTime)
 
   def runningLiveAppDeployments(gitHubDeployments: List[Deployment]): List[RunningLiveAppDeployment] = {
     gitHubDeployments
       .filter(deployment => deployment.state == "PENDING" && deployment.latestStatus.flatMap(_.description).isDefined)
-      .map(deployment => RunningLiveAppDeployment(deployment.latestStatus.get.description.get, deployment.environment, deployment.databaseId))
+      .map(deployment => RunningLiveAppDeployment(deployment.latestStatus.get.description.get, deployment.environment, deployment.databaseId, deployment.createdAt))
   }
 
 }

--- a/src/main/scala/com/gu/githubapi/GitHubApi.scala
+++ b/src/main/scala/com/gu/githubapi/GitHubApi.scala
@@ -1,5 +1,7 @@
 package com.gu.githubapi
 
+import java.time.ZonedDateTime
+
 import com.gu.config.Config.GitHubConfig
 import com.gu.githubapi.Conversion.{ RunningLiveAppDeployment, runningLiveAppDeployments }
 import com.gu.okhttp.SharedClient
@@ -18,7 +20,7 @@ object GitHubApi {
   case class GitHubApiException(message: String) extends Throwable(message: String)
 
   case class Node(node: Deployment)
-  case class Deployment(databaseId: Int, environment: String, state: String, latestStatus: Option[LatestStatus])
+  case class Deployment(databaseId: Int, environment: String, state: String, latestStatus: Option[LatestStatus], createdAt: ZonedDateTime)
   case class LatestStatus(description: Option[String])
 
   val deploymentsDecoder = Decoder[List[Node]].prepare(
@@ -44,7 +46,7 @@ object GitHubApi {
     val query =
       """
     |{
-    |	"query": "query { repository(owner:\"guardian\", name:\"ios-live\") { deployments(last: 10) { edges { node { databaseId, createdAt, environment, state, payload, latestStatus { createdAt, description  } } } } } }"
+    |	"query": "query { repository(owner:\"guardian\", name:\"ios-live\") { deployments(last: 10) { edges { node { databaseId, createdAt, environment, state, latestStatus { createdAt, description  } } } } } }"
     |}
     |""".stripMargin
     for {

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -49,7 +49,7 @@ object Lambda {
             AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig)
           case (_, None) =>
             if (olderThanOneHour(runningDeployment)) {
-              logger.info(s"Deployment was created at ${runningDeployment.createdAt}, but there is still no record of the associated build in App Store Connect...")
+              logger.info(s"Deployment for ${runningDeployment.version} was created at ${runningDeployment.createdAt}, but there is still no record of the associated build in App Store Connect...")
               GitHubApi.markDeploymentAsFailure(gitHubConfig, runningDeployment)
             } else {
               Try(logger.info(s"Found running beta deployment ${runningDeployment.version}, but build was not present in App Store Connect response yet..."))

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -39,10 +39,10 @@ object Lambda {
           case ("external-beta", Some(LiveAppBeta(_, _, _, _, "IN_BETA_TESTING"))) =>
             logger.info(s"External beta deployment for ${runningDeployment.version} is complete...")
             GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)
-          case ("external-beta", Some(build@LiveAppBeta(_, _, _, "IN_BETA_TESTING", "READY_FOR_BETA_SUBMISSION"))) =>
+          case ("external-beta", Some(build @ LiveAppBeta(_, _, _, "IN_BETA_TESTING", "READY_FOR_BETA_SUBMISSION"))) =>
             logger.info(s"External beta deployment for ${runningDeployment.version} can now be submitted for review...")
             AppStoreConnectApi.submitForBetaTesting(appStoreConnectToken, build.buildId)
-          case ("external-beta", Some(build@LiveAppBeta(_, _, _, _, "BETA_APPROVED"))) =>
+          case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "BETA_APPROVED"))) =>
             logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
             AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig)
           case (_, None) =>

--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -48,14 +48,14 @@ object Lambda {
             logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
             AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig)
           case (_, None) =>
-            Try(logger.info(s"Found running beta deployment ${runningDeployment.version}, but build was not present in App Store Connect response"))
-          case _ =>
             if (olderThanOneHour(runningDeployment)) {
               logger.info(s"Deployment was created at ${runningDeployment.createdAt}, but there is still no record of the associated build in App Store Connect...")
               GitHubApi.markDeploymentAsFailure(gitHubConfig, runningDeployment)
             } else {
-              Try(logger.info(s"No action was required for beta deployment ${runningDeployment.version}. Full details are: $attemptToFindBeta"))
+              Try(logger.info(s"Found running beta deployment ${runningDeployment.version}, but build was not present in App Store Connect response yet..."))
             }
+          case _ =>
+            Try(logger.info(s"No action was required for beta deployment ${runningDeployment.version}. Full details are: $attemptToFindBeta"))
         }
       case None =>
         Try(logger.info("No running beta deployments found."))

--- a/src/test/scala/com/gu/githubapi/ConversionTest.scala
+++ b/src/test/scala/com/gu/githubapi/ConversionTest.scala
@@ -1,20 +1,25 @@
 package com.gu.githubapi
 
+import java.time.ZonedDateTime
+
 import com.gu.githubapi.Conversion.RunningLiveAppDeployment
 import com.gu.githubapi.GitHubApi.{ Deployment, LatestStatus }
 import org.scalatest.FunSuite
 
 class ConversionTest extends FunSuite {
 
+  val now = ZonedDateTime.now()
+
   val deployment = Deployment(
     123,
     "external-beta",
     "PENDING",
-    Some(LatestStatus(Some("12345"))))
+    Some(LatestStatus(Some("12345"))),
+    now)
 
   test("runningLiveAppDeployments should collect pending deployments with version info") {
     val result = Conversion.runningLiveAppDeployments(List(deployment))
-    val expected = List(RunningLiveAppDeployment("12345", "external-beta", 123))
+    val expected = List(RunningLiveAppDeployment("12345", "external-beta", 123, now))
     assert(result == expected)
   }
 


### PR DESCRIPTION
## What does this change?

We recently had an issue where an iOS beta deployment was cancelled midway through. This created a weird state where the iOS deployments lambda function was polling/waiting for a build to appear in App Store Connect, but the build was never going to show up. Because we only attempt to process [a single beta deployment per lambda invocation](https://github.com/guardian/live-app-versions/blob/main/src/main/scala/com/gu/iosdeployments/Lambda.scala#L88), everything got a bit stuck due to this 🙈 

It was possible for this problem to happen if the upload build script was interrupted whilst executing one of [these tasks](https://github.com/guardian/ios-live/blob/03abcc3e8901f7f6d427d3ffc6410d840ce943b1/GLA/fastlane/Fastfile#L70-L101). An equivalent problem could have affected production deployments if the script was interrupted during [this phase](https://github.com/guardian/ios-live/blob/03abcc3e8901f7f6d427d3ffc6410d840ce943b1/GLA/fastlane/Fastfile#L124-L146).

To work around these types of problems, we now mark deployments as failed if there is no record of them in App Store Connect one hour after they've been started.