### PR TITLE
Handle expired beta

### DIFF
--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -47,6 +47,9 @@ object Lambda {
           case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "BETA_APPROVED"))) =>
             logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
             AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig)
+          case (_, Some(LiveAppBeta(_, _, _, "EXPIRED", "EXPIRED"))) =>
+            logger.info(s"Beta deployment for ${runningDeployment.version} was (presumably) successful, but beta build was expired before deployment completed...")
+            GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)
           case (_, None) =>
             notPresentInAppStoreConnect(runningDeployment, gitHubConfig)
           case _ =>


### PR DESCRIPTION
## What does this change?
From https://github.com/guardian/ios-live/deployments#activity-log we can see that many of the iOS deployments in the last week are still `pending`. We have also observed that our external betas have not been automatically distributed to testers.

From the CloudWatch logs, I can see that we have the message 
``` 
No action was required for beta deployment 18055. Full details are: Some(LiveAppBeta(18055,2f17f9c8-1227-4fe1-932a-f04767c92af3,2021-02-12T10:26:45Z,EXPIRED,EXPIRED))
```
and in AppStoreConnect, I can see that the build 18055 was expired (I believe to avoid confusion, since someone was kicking off lots of internal betas in order to test something).

Because 18055 was expired before the lambda ran, the deployment was not marked as completed, but remained pending indefinitely. The lambda checks only the first incomplete beta deployment - so because it kept thinking there was nothing to do with that deployment, it then never actioned any of the more recent ones.

To resolve this issue, I have added a step to check for expired builds, and mark them as a successful deployment. Once this has taken effect, 18055 should be marked as completed, and the more recent builds processed (in chronological order) as usual.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Should probably deploy this to code first? I'm planning on getting someone from MSS to help me with that.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
All deployments on https://github.com/guardian/ios-live/deployments/activity_log should be marked as completed.
The recent external betas should be submitted for review/distributed to external testers.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

I also considered having the lambda loop over _every_ incomplete beta deployment (rather than handling _only_ the first one each time) but I was concerned that if we ever again ended up with a long list of incomplete deployments, it could lead to a lot of processing. We rarely intend to have a situation with multiple pending deployments - and when we do, it is usually the correct thing to handle them in order. I'm open to other opinions on this though!

Because we've released more than one external beta since this problem occurred, I expect that both will be distributed to external testers in quick succession. I think that's fine - some users may get multiple notifications, but I imagine most have automatic updates turned on and won't even notice.

