### PR TITLE
Don't automatically distribute iOS external betas to group 1

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -109,10 +109,6 @@ object AppStoreConnectApi {
                   |{
                   |  "data": [
                   |     {
-                  |       "id": "${externalTesterConfig.group1.id}",
-                  |         "type": "betaGroups"
-                  |     },
-                  |     {
                   |       "id": "${externalTesterConfig.group2.id}",
                   |         "type": "betaGroups"
                   |     }


### PR DESCRIPTION
## What does this change?
In accordance with https://docs.google.com/document/d/1UslKo11pxv4_xXJsZsxQwjFr5YN0VuqxKu40_IQQPUI/edit?disco=AAAAL0BTYrk, this is a temporary change to only distribute external betas to group 2 (the slightly smaller beta group). We will be be manually distributing builds from an alternative branch to group 1.

We expect to undo this change around the 29th March.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
The automated beta will go out soon, and we will double-check which groups it has been distributed to. We are also able to manually trigger this.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
If beta is still distributed to both groups: Not the end of the world, we can simply fix and try again with the next automated beta.
If beta is distributed to neither group: Not the end of the world, we can manually add the appropriate group after the fact.
