### PR TITLE
Revert "Don't automatically distribute iOS external betas to group 1"

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -109,6 +109,10 @@ object AppStoreConnectApi {
                   |{
                   |  "data": [
                   |     {
+                  |       "id": "${externalTesterConfig.group1.id}",
+                  |         "type": "betaGroups"
+                  |     },
+                  |     {
                   |       "id": "${externalTesterConfig.group2.id}",
                   |         "type": "betaGroups"
                   |     }


### PR DESCRIPTION
Reverts guardian/live-app-versions#30 because we have enough data for our test, and would like to go back to releasing builds to both groups.