### PR TITLE
Update PlayDeveloperApi for better debuggability

### DIFF
--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -47,6 +47,9 @@ object Lambda {
           case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "BETA_APPROVED"))) =>
             logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
             AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig)
+          case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "BETA_REJECTED"))) =>
+            logger.info(s"External beta for ${runningDeployment.version} was rejected.")
+            GitHubApi.markDeploymentAsFailure(gitHubConfig, runningDeployment)
           case (_, Some(LiveAppBeta(_, _, _, "EXPIRED", "EXPIRED"))) =>
             logger.info(s"Beta deployment for ${runningDeployment.version} was (presumably) successful, but beta build was expired before deployment completed...")
             GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)

--- a/src/main/scala/com/gu/playdeveloperapi/PlayDeveloperApi.scala
+++ b/src/main/scala/com/gu/playdeveloperapi/PlayDeveloperApi.scala
@@ -28,7 +28,7 @@ object PlayDeveloperApi {
 
       for {
         httpResponse <- Try(SharedClient.client.newCall(request).execute)
-        bodyAsString <- SharedClient.getResponseBodyIfSuccessful("Google Play Developer API", httpResponse)
+        bodyAsString <- SharedClient.getResponseBodyIfSuccessful("Google Play Developer API Response: (edits.insert) ", httpResponse)
         editId <- decode[EditId](bodyAsString).toTry
       } yield {
         logger.info(s"The response for edit ID: $bodyAsString")
@@ -48,7 +48,7 @@ object PlayDeveloperApi {
 
       for {
         httpResponse <- Try(SharedClient.client.newCall(request).execute)
-        bodyAsString <- SharedClient.getResponseBodyIfSuccessful("Google Play Developer API", httpResponse)
+        bodyAsString <- SharedClient.getResponseBodyIfSuccessful("Google Play Developer API Response: (edits.tracks.list) ", httpResponse)
         tracksResponse <- decode[TracksResponse](bodyAsString).toTry
       } yield {
         logger.info(s"The response for tracks: $bodyAsString")


### PR DESCRIPTION
## What does this change?
Distinguish between the responses returned from the Google Play Developer API. 

In particular the logging of the responses:

edits.insert
https://developers.google.com/android-publisher/api-ref/rest/v3/edits/insert 

and

edit.tracks.list
https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks/list

should be made distinct for better debuggability
