### PR TITLE
LIVE-2478: Handle rejected beta deployments

### DIFF
--- a/src/main/scala/com/gu/iosdeployments/Lambda.scala
+++ b/src/main/scala/com/gu/iosdeployments/Lambda.scala
@@ -47,6 +47,9 @@ object Lambda {
           case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "BETA_APPROVED"))) =>
             logger.info(s"External beta deployment for ${runningDeployment.version} can now be distributed to users...")
             AppStoreConnectApi.distributeToExternalTesters(appStoreConnectToken, build.buildId, externalTesterConfig)
+          case ("external-beta", Some(build @ LiveAppBeta(_, _, _, _, "BETA_REJECTED"))) =>
+            logger.info(s"External beta for ${runningDeployment.version} was rejected.")
+            GitHubApi.markDeploymentAsFailure(gitHubConfig, runningDeployment)
           case (_, Some(LiveAppBeta(_, _, _, "EXPIRED", "EXPIRED"))) =>
             logger.info(s"Beta deployment for ${runningDeployment.version} was (presumably) successful, but beta build was expired before deployment completed...")
             GitHubApi.markDeploymentAsSuccess(gitHubConfig, runningDeployment)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
We [once again](https://github.com/guardian/live-app-versions/pull/29) have multiple pending deployments, this time because one was rejected during beta review. This change should mark that beta deployment as failed, and then go on to process the rest of them normally.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
No way to test, except by deploying live, there is no CODE version of App store connect.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The pending deployments in github should be processed.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Low risk.