### PR TITLE
Bump aws-java-sdk-s3 To v1.12.101

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,7 @@ scalacOptions ++= Seq(
 val circeVersion = "0.12.3"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.714",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.1", // Pin a more recent version to avoid Snyk vulnerabilities introduced by s3 sdk
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.12.101",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
   "com.google.auth" % "google-auth-library-oauth2-http" % "0.20.0",


### PR DESCRIPTION
## What does this change?

Bumps `aws-java-sdk-s3` To v1.12.101.

## How to test

@frankie297 @ddramowicz any thoughts on the best way to test this still works?

## How can we measure success?

It works the same, but the dependencies are up-to-date.
