### PR TITLE
update log4j version to fix security vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val circeVersion = "0.12.3"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % "1.12.101",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0",
   "com.google.auth" % "google-auth-library-oauth2-http" % "0.20.0",
   "com.gu" %% "simple-configuration-ssm" % "1.4.1",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.15.0",

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "org.slf4j" % "slf4j-api" % "1.7.30",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2"
+  "junit" % "junit" % "4.13.2"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,8 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "org.slf4j" % "slf4j-api" % "1.7.30",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
+  "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,8 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "org.slf4j" % "slf4j-api" % "1.7.30",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
+  "junit" % "junit" % "4.13.1"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "org.slf4j" % "slf4j-api" % "1.7.30",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "junit" % "junit" % "4.13.2"
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -20,10 +20,10 @@ val circeVersion = "0.12.3"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % "1.12.101",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",
   "com.google.auth" % "google-auth-library-oauth2-http" % "0.20.0",
   "com.gu" %% "simple-configuration-ssm" % "1.4.1",
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.8.2",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.15.0",
   "com.pauldijou" %% "jwt-core" % "4.2.0",
   "com.squareup.okhttp3" % "okhttp" % "4.3.1",
   "com.eatthepath" % "pushy" % "0.15.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?
Update log4j dependency to fix security vulnerability - see [doc](https://docs.google.com/document/d/1nVKsXiEXLviHOMY1iQEoyacvN93_SYCQwsOFfaP-dxo)

It also adds a dependency graph plugin so we can run the command `sbt dependencyBrowseTree` which a handy way to quickly view our dependency tree in a browser: https://github.com/sbt/sbt-dependency-graph

## How to test

Ran tests locally