### PR TITLE
Bump the versions of netty, jackson and okhttp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,15 +18,15 @@ scalacOptions ++= Seq(
 val circeVersion = "0.12.3"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.12.101",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.12.296",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0",
   "com.google.auth" % "google-auth-library-oauth2-http" % "0.20.0",
   "com.gu" %% "simple-configuration-ssm" % "1.5.7",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.17.1",
   "com.pauldijou" %% "jwt-core" % "4.2.0",
-  "com.squareup.okhttp3" % "okhttp" % "4.3.1",
-  "com.eatthepath" % "pushy" % "0.15.0",
+  "com.squareup.okhttp3" % "okhttp" % "4.9.2",
+  "com.eatthepath" % "pushy" % "0.15.1",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,


### PR DESCRIPTION
## What does this change?

The PR bumps the versions of netty, jackson and okhttp to fix the snyk vulnerabilities.

## How to test

All test cases passed.  Snyk local scan confirmed the vulnerabilities were fixed.

