### PR TITLE
Migrate build to GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
         uses: guardian/actions-riff-raff@v2
         with:
           app: live-app-versions
+          buildNumberOffset: 172
           configPath: riff-raff.yaml
           contentDirectories: |
             live-app-versions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,16 @@
 name: Build
 
 on:
-#  push:
-#    branches:
-#      - main
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 
-# we might need this to allow queued workflows to interrupt previous runs
-#concurrency:
-#  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-#  cancel-in-progress: true
+# allow queued workflows to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,16 @@ jobs:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
-      - name: Compile, test and upload to riff raff
-        run: sbt clean compile test riffRaffUpload
+      - name: Clean, compile and test
+        run: sbt clean compile test
+
+      - name: Upload to riff-raff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          app: live-app-versions
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            live-app-versions:
+              - target/live-app-versions.jar
+            live-app-versions-cfn:
+              - cfn.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+#  push:
+#    branches:
+#      - main
+#  pull_request:
+  workflow_dispatch:
+
+# we might need this to allow queued workflows to interrupt previous runs
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+#  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          cache: sbt
+          java-version: 8
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+
+      - name: Compile, test and upload to riff raff
+        run: sbt clean compile test riffRaffUpload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,6 @@ jobs:
           configPath: riff-raff.yaml
           contentDirectories: |
             live-app-versions:
-              - target/live-app-versions.jar
+              - target/scala-2.12/live-app-versions.jar
             live-app-versions-cfn:
               - cfn.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Clean, compile and test
-        run: sbt clean compile test
+        run: sbt clean compile test assembly
 
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
 #  push:
 #    branches:
 #      - main
-#  pull_request:
+  pull_request:
   workflow_dispatch:
 
 # we might need this to allow queued workflows to interrupt previous runs


### PR DESCRIPTION
## What does this change?

This PR enables us to build the project using GitHub actions instead of TeamCity. Given TeamCity will be retiring in September 2023 this migration is important.

The new `build` workflow replicates the 2 build steps we see in the existing TeamCity configuration:
- cleans, compiles and tests the project (as well as an extra step to assemble to target jar, which I believe was something previously carried out by the riffRaffUpload command)
- it replaces the `sbt-riffraff-artifact` plugin with the language-agnostic [riff-raff-action](https://github.com/guardian/actions-riff-raff)
 
<img width="746" alt="Screenshot 2023-05-26 at 11 17 47" src="https://github.com/guardian/live-app-versions/assets/45561419/ddfb3715-a418-40c1-818f-067d3ce0b421">

### Follow-on tasks

After this change has been merged and tested it might be good to consider some follow-on tasks:
- Remove the sbt plugin `riff-raff-artifact` from the project
- Update to java 11
- Migrate to cdk

## How to test

After the GitHub action had built and deployed the riffRaff artifacts I could deploy these via riff-raff to CODE.

Note that in riff-raff the project was prefixed by the stack, i.e. `mobile::live-app-versions`, instead of `live-app-versions`.

<img width="633" alt="Screenshot 2023-05-26 at 11 23 05" src="https://github.com/guardian/live-app-versions/assets/45561419/2d482160-8678-4f02-8382-8386d8c1b4d5">

I compared the app version retrieved before and after the new deployment, they were identical:

Before:
```
2023-05-26 09:31:58 [main]  INFO  PlayDeveloperApi$PlayDeveloperApi$:54 - The response for tracks: {
  "kind": "androidpublisher#tracksListResponse",
  "tracks": [
    {
      "track": "production",
      "releases": [
        {
          "name": "6.105.18803",
          "versionCodes": [
            "18803"
          ],
```

After:
```
2023-05-26 09:38:31 [main]  INFO  PlayDeveloperApi$PlayDeveloperApi$:54 - The response for tracks: {
  "kind": "androidpublisher#tracksListResponse",
  "tracks": [
    {
      "track": "production",
      "releases": [
        {
          "name": "6.105.18803",
          "versionCodes": [
            "18803"
          ],
```