### PR TITLE
Remove sbt-riffraff-artifact plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,8 +35,6 @@ libraryDependencies ++= Seq(
   "junit" % "junit" % "4.13.1"
 )
 
-enablePlugins(RiffRaffArtifact)
-
 assemblyJarName := s"${name.value}.jar"
 assembly / assemblyMergeStrategy := {
   case "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat" => MergeStrategy.last
@@ -45,8 +43,3 @@ assembly / assemblyMergeStrategy := {
   case "META-INF/MANIFEST.MF" => MergeStrategy.discard
   case x => MergeStrategy.first
 }
-
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (file("cfn.yaml"), s"${name.value}-cfn/cfn.yaml")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
 
 addDependencyTreePlugin


### PR DESCRIPTION
## What does this change?

Now this project uses [actions-riff-raff](https://github.com/guardian/actions-riff-raff) we can remove the use of the sbt plugin.

Actions-riff-raff is probably a more simple choice going forward: it allows us to abstract as much of the build/deploy config from our code + build.sbt as possible.

## How to test

I triggered the build workflow manually, the action was [successful](https://github.com/guardian/live-app-versions/actions/runs/5357829216). This means that the project compile, artefacts generated and uploaded to the riff-raff s3 bucket.

I was able to successfully deploy the corresponding build into CODE:
<img width="1283" alt="Screenshot 2023-06-23 at 16 17 28" src="https://github.com/guardian/live-app-versions/assets/45561419/4af139b1-e38c-4d50-8ed1-164d28278e33">

I triggered one of the lambdas via the AWS console. The invocation was successful:
<img width="1306" alt="Screenshot 2023-06-23 at 16 18 23" src="https://github.com/guardian/live-app-versions/assets/45561419/0679987c-5489-4af5-a89c-cb393276085e">

I think the above steps validate that the build/deploy process still works as expected without affecting the application code that's generated/executed.

