### PR TITLE
Increase app store connect api timeout

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -104,7 +104,7 @@ Resources:
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
-      Timeout: 60
+      Timeout: 120
 
   IosLiveAppVersionsLambda:
     Type: AWS::Lambda::Function

--- a/src/main/scala/com/gu/okhttp/SharedClient.scala
+++ b/src/main/scala/com/gu/okhttp/SharedClient.scala
@@ -3,6 +3,7 @@ package com.gu.okhttp
 import okhttp3.{ OkHttpClient, Response }
 import org.slf4j.{ Logger, LoggerFactory }
 
+import java.util.concurrent.TimeUnit
 import scala.util.{ Failure, Success, Try }
 
 case class ApiException(message: String) extends Throwable(message: String)
@@ -11,7 +12,10 @@ object SharedClient {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  val client = new OkHttpClient
+  val client = new OkHttpClient.Builder()
+    .readTimeout(40, TimeUnit.SECONDS)
+    .connectTimeout(40, TimeUnit.SECONDS)
+    .build()
 
   def getResponseBodyIfSuccessful(apiName: String, response: Response): Try[String] = {
     val responseBody = response.body().string()


### PR DESCRIPTION
## What does this change?

The server alerts channel is getting a little noisy because, over the past couple of months, we've seen an increase in the number of failures of the ios-deployments lambda:

<img width="800px" alt="Screenshot 2023-09-14 at 13 58 25" src="https://github.com/guardian/live-app-versions/assets/45561419/b86809c9-1dec-4450-bc07-fd046460691f">

This PR aims to address these failures by increasing the http client's timeout. We checked the api [docs](https://developer.apple.com/documentation/appstoreconnectapi) and didn't find any mention of why the api wouldn't return a response. If the response was being throttled we would expect to be returned a [429](https://developer.apple.com/documentation/appstoreconnectapi/identifying_rate_limits) instead of the response hanging. 

The okhttp library has a default timeout of [10 seconds](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/connect-timeout/) and through experimentation on our local machines we could see:
- the request to the /builds api took ~3seconds
- the request to the /apps/{appId} api would take up to 30 seconds but was being interrupted (due to the http client timeout) after 10 seconds

<img width="800px" alt="Screenshot 2023-09-14 at 14 52 36" src="https://github.com/guardian/live-app-versions/assets/45561419/125a7877-bdd5-47be-a9de-2fad83631620">

In this PR we increase the client timeout to 40 seconds. The http client is shared by all lambdas, so this increase in the timeout will affect all lambdas. However, only the ios-deployments lambda is currently failing so it's anticipated that only this lambda will make use of the increased timeout. As a result we've only increased the lambda timeout for ios-deployments.

## How to test

The change was tested locally, the logs show that the lambda executed successfully, with the /apps/{appId} request taking ~30seconds:

<img src="https://github.com/guardian/live-app-versions/assets/45561419/fb9b9e59-7528-4412-ac78-964ef7768a0c" width="800px" />

The change was deployed to CODE and the execution was also successful:

<img width="800px" alt="Screenshot 2023-09-14 at 13 57 56" src="https://github.com/guardian/live-app-versions/assets/45561419/d42f9334-41a0-4f67-a5a9-62eff6e7c76a">

