### PR TITLE
Increase the api timeout (again)

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -104,7 +104,7 @@ Resources:
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
-      Timeout: 120
+      Timeout: 240
 
   IosLiveAppVersionsLambda:
     Type: AWS::Lambda::Function

--- a/src/main/scala/com/gu/okhttp/SharedClient.scala
+++ b/src/main/scala/com/gu/okhttp/SharedClient.scala
@@ -13,8 +13,8 @@ object SharedClient {
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   val client = new OkHttpClient.Builder()
-    .readTimeout(40, TimeUnit.SECONDS)
-    .connectTimeout(40, TimeUnit.SECONDS)
+    .readTimeout(80, TimeUnit.SECONDS)
+    .connectTimeout(80, TimeUnit.SECONDS)
     .build()
 
   def getResponseBodyIfSuccessful(apiName: String, response: Response): Try[String] = {


### PR DESCRIPTION
## What does this change?

In [this](https://github.com/guardian/live-app-versions/pull/51) PR we increased the timeout of the http client to try and reduce the number of timeout exceptions we were seeing. We've just seen an error in PROD:
<img width="1479" alt="Screenshot 2023-09-22 at 16 44 38" src="https://github.com/guardian/live-app-versions/assets/45561419/630ddf7a-4ebe-4e82-9971-a789ad63001a">

As a result I think it's worth increasing again. When we did local testing before the response time varied a lot so I don't think there's a huge amount of harm in increasing the timeout even further.

I've doubled both the http client timeouts and the lambda timeout accordingly.

## How can we measure success?

After this has been merged to PROD we'll continue to monitor the mobile server alerts channel, if we see more timeout errors we may like to re-assess our approach.