### PR TITLE
Bump netty to fix snyk vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.9" % "test",
   "junit" % "junit" % "4.13.2",
   "io.netty" % "netty-codec-http2" % "4.1.100.Final",
-  "io.netty" % "netty-codec-http2" % "4.1.100.Final",
   "io.netty" % "netty-handler-proxy" % "4.1.100.Final",
   "io.netty" % "netty-resolver-dns" % "4.1.100.Final",
   "io.netty" % "netty-transport-native-epoll" % "4.1.100.Final",

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,12 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "org.slf4j" % "slf4j-api" % "1.7.36",
   "org.scalatest" %% "scalatest" % "3.0.9" % "test",
-  "junit" % "junit" % "4.13.2"
+  "junit" % "junit" % "4.13.2",
+  "io.netty" % "netty-codec-http2" % "4.1.100.Final",
+  "io.netty" % "netty-codec-http2" % "4.1.100.Final",
+  "io.netty" % "netty-handler-proxy" % "4.1.100.Final",
+  "io.netty" % "netty-resolver-dns" % "4.1.100.Final",
+  "io.netty" % "netty-transport-native-epoll" % "4.1.100.Final",
 )
 
 assemblyJarName := s"${name.value}.jar"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The Snyk scanning identified a high severity vulnerability on `io.netty:netty-codec-http2`.  The vulnerability has been fixed in version `4.1.100.Final`

This PR bumps the netty dependencies to `4.1.100.Final` to fix it.

All unit tests passed.
