### PR TITLE
Add Guardian Staff to beta tester groups

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -115,6 +115,10 @@ object AppStoreConnectApi {
                   |     {
                   |       "id": "${externalTesterConfig.group2.id}",
                   |         "type": "betaGroups"
+                  |     },
+                  |     {
+                  |       "id": "${externalTesterConfig.group3.id}",
+                  |         "type": "betaGroups"
                   |     }
                   |  ]
                   |}
@@ -128,7 +132,7 @@ object AppStoreConnectApi {
       httpResponse <- Try(SharedClient.client.newCall(request).execute)
       _ <- SharedClient.getResponseBodyIfSuccessful("App Store Connect API", httpResponse)
     } yield {
-      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1} and ${externalTesterConfig.group2}")
+      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1}, ${externalTesterConfig.group2} and ${externalTesterConfig.group3}")
     }
   }
 

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -66,13 +66,15 @@ object Config {
   }
 
   case class ExternalTesterGroup(id: String, name: String)
-  case class ExternalTesterConfig(group1: ExternalTesterGroup, group2: ExternalTesterGroup)
+  case class ExternalTesterConfig(group1: ExternalTesterGroup, group2: ExternalTesterGroup, group3: ExternalTesterGroup)
   val externalTesterConfigForProd = ExternalTesterConfig(
     ExternalTesterGroup("b3ee0d21-fe7e-487a-9f81-5ea993b6e860", "External Testers 1"),
-    ExternalTesterGroup("53ab9951-d444-4107-87ce-dbfbb2c898e5", "External Testers 2"))
+    ExternalTesterGroup("53ab9951-d444-4107-87ce-dbfbb2c898e5", "External Testers 2"),
+    ExternalTesterGroup("3f5f1a35-dd71-4e11-8643-b20d0939c071", "Guardian Staff"))
   val externalTesterConfigForTesting = ExternalTesterConfig(
     ExternalTesterGroup("2c761621-6849-46c5-a936-fecc1187d736", "Live App Versions Testers 1"),
-    ExternalTesterGroup("d3fc87fc-7416-41ae-8ff9-2a1d8a6c619a", "Live App Versions Testers 2"))
+    ExternalTesterGroup("d3fc87fc-7416-41ae-8ff9-2a1d8a6c619a", "Live App Versions Testers 2"),
+    ExternalTesterGroup("3f5f1a35-dd71-4e11-8643-b20d0939c071", "Guardian Staff"))
 
   case class GitHubConfig(token: String)
 


### PR DESCRIPTION
## What does this change?

The [iosdeployments lambda](https://github.com/guardian/live-app-versions/blob/main/src/main/scala/com/gu/iosdeployments/Lambda.scala) runs every 5 minutes to carry out a number of actions related to new deployments of the app. One of the tasks it carries out is [distributing builds to external beta testers](https://github.com/guardian/live-app-versions/blob/41bbbe6a4e38879f7be1dfcf8ba2ef434319ed06/src/main/scala/com/gu/iosdeployments/Lambda.scala#L49), which we have defined in TestFlight. A new group of testers has been added to TestFlight since this lambda was first created ([Guardian Staff](https://appstoreconnect.apple.com/apps/409128287/testflight/groups/3f5f1a35-dd71-4e11-8643-b20d0939c071)), and this PR ensures that this group is added automatically to new beta builds, in addition to External Testers 1 and External Testers 2. 

## How to test

Next time we do a beta of the iOS app, check in [TestFlight](https://appstoreconnect.apple.com/apps/409128287/testflight/ios) to see if the Guardian Staff tester group has been added (represented by the GS circle in the Groups column below):

![image](https://github.com/guardian/live-app-versions/assets/23078809/5ee09dc3-6670-4241-985b-56a07d8329b0)