### PR TITLE
Temporarily pause automatically distributing to External Testers 2

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -113,10 +113,6 @@ object AppStoreConnectApi {
                   |         "type": "betaGroups"
                   |     },
                   |     {
-                  |       "id": "${externalTesterConfig.group2.id}",
-                  |         "type": "betaGroups"
-                  |     },
-                  |     {
                   |       "id": "${externalTesterConfig.group3.id}",
                   |         "type": "betaGroups"
                   |     }
@@ -132,7 +128,7 @@ object AppStoreConnectApi {
       httpResponse <- Try(SharedClient.client.newCall(request).execute)
       _ <- SharedClient.getResponseBodyIfSuccessful("App Store Connect API", httpResponse)
     } yield {
-      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1}, ${externalTesterConfig.group2} and ${externalTesterConfig.group3}")
+      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1} and ${externalTesterConfig.group3}")
     }
   }
 

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -66,14 +66,12 @@ object Config {
   }
 
   case class ExternalTesterGroup(id: String, name: String)
-  case class ExternalTesterConfig(group1: ExternalTesterGroup, group2: ExternalTesterGroup, group3: ExternalTesterGroup)
+  case class ExternalTesterConfig(group1: ExternalTesterGroup, group3: ExternalTesterGroup)
   val externalTesterConfigForProd = ExternalTesterConfig(
     ExternalTesterGroup("b3ee0d21-fe7e-487a-9f81-5ea993b6e860", "External Testers 1"),
-    ExternalTesterGroup("53ab9951-d444-4107-87ce-dbfbb2c898e5", "External Testers 2"),
     ExternalTesterGroup("3f5f1a35-dd71-4e11-8643-b20d0939c071", "Guardian Staff"))
   val externalTesterConfigForTesting = ExternalTesterConfig(
     ExternalTesterGroup("2c761621-6849-46c5-a936-fecc1187d736", "Live App Versions Testers 1"),
-    ExternalTesterGroup("d3fc87fc-7416-41ae-8ff9-2a1d8a6c619a", "Live App Versions Testers 2"),
     ExternalTesterGroup("3f5f1a35-dd71-4e11-8643-b20d0939c071", "Guardian Staff"))
 
   case class GitHubConfig(token: String)


### PR DESCRIPTION
## What does this change?

In preparation for Xcode 16, we want to set up a separate beta build pipeline. The purpose of this is to allow us to test what is in main from the latest Xcode before it is released in September. More details on the process are in [this document](https://docs.google.com/document/d/1KT7PMhYluSJ700yTtxI_PXlty9tYA4myLQxVIp46dNc/edit). 

We plan to ship Xcode 16 betas to External Testers 2 only, which means we need to stop that group being added automatically to our regular Xcode 15 betas. Once this experimental phase is over and we've fully moved over to Xcode, we will revert this PR and have both tester groups automatically added to each new beta build again. 

## How to test

The next beta build is due to go out on Monday evening. Once it has been approved by Apple, the iosdeployments lambda should automatically add External Testers 1 and Guardian Staff to that build, but not External Testers 2. Furthermore, once we create the Xcode 16 beta manually and upload it to App Store Connect, this lambda should _not_ add External Testers 1 and Guardian staff to that build. 