### PR TITLE
Fix vulnerability in jackson core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ libraryDependencies ++= Seq(
   "io.netty" % "netty-handler-proxy" % "4.1.112.Final",
   "io.netty" % "netty-resolver-dns" % "4.1.112.Final",
   "io.netty" % "netty-transport-native-epoll" % "4.1.112.Final",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.17.2"
 )
 
 assemblyJarName := s"${name.value}.jar"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds the latest jackson library explicitly to address a vulnerability introduced by an older version of this. 

![jackson-vulnerability](https://github.com/user-attachments/assets/cf7a7682-91fa-437a-980a-879028b1b199)


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
