### PR TITLE
Add External Testers 3, 4, 5 to iosdeployments lambda

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -115,6 +115,18 @@ object AppStoreConnectApi {
                   |     {
                   |       "id": "${externalTesterConfig.group3.id}",
                   |         "type": "betaGroups"
+                  |     },
+                  |     {
+                  |       "id": "${externalTesterConfig.group4.id}",
+                  |         "type": "betaGroups"
+                  |     },
+                  |     {
+                  |       "id": "${externalTesterConfig.group5.id}",
+                  |         "type": "betaGroups"
+                  |     },
+                  |     {
+                  |       "id": "${externalTesterConfig.group6.id}",
+                  |         "type": "betaGroups"
                   |     }
                   |  ]
                   |}
@@ -128,7 +140,8 @@ object AppStoreConnectApi {
       httpResponse <- Try(SharedClient.client.newCall(request).execute)
       _ <- SharedClient.getResponseBodyIfSuccessful("App Store Connect API", httpResponse)
     } yield {
-      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1} and ${externalTesterConfig.group3}")
+      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1}, ${externalTesterConfig.group3}, " +
+        s"${externalTesterConfig.group4}, ${externalTesterConfig.group5}, and ${externalTesterConfig.group6}")
     }
   }
 

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -66,9 +66,16 @@ object Config {
   }
 
   case class ExternalTesterGroup(id: String, name: String)
-  case class ExternalTesterConfig(group1: ExternalTesterGroup, group3: ExternalTesterGroup)
+  case class ExternalTesterConfig(group1: ExternalTesterGroup,
+                                  group3: ExternalTesterGroup,
+                                  group4: ExternalTesterGroup,
+                                  group5: ExternalTesterGroup,
+                                  group6: ExternalTesterGroup)
   val externalTesterConfigForProd = ExternalTesterConfig(
     ExternalTesterGroup("b3ee0d21-fe7e-487a-9f81-5ea993b6e860", "External Testers 1"),
+    ExternalTesterGroup("a84bf09f-adf2-403e-a69e-8636cba7cedd", "External Testers 3"),
+    ExternalTesterGroup("71e65c76-50b3-412f-8f95-c0195e8716ee", "External Testers 4"),
+    ExternalTesterGroup("75de0034-ffe3-475d-bba9-73016808d473", "External Testers 5"),
     ExternalTesterGroup("3f5f1a35-dd71-4e11-8643-b20d0939c071", "Guardian Staff"))
   val externalTesterConfigForTesting = ExternalTesterConfig(
     ExternalTesterGroup("2c761621-6849-46c5-a936-fecc1187d736", "Live App Versions Testers 1"),

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -79,6 +79,9 @@ object Config {
     ExternalTesterGroup("3f5f1a35-dd71-4e11-8643-b20d0939c071", "Guardian Staff"))
   val externalTesterConfigForTesting = ExternalTesterConfig(
     ExternalTesterGroup("2c761621-6849-46c5-a936-fecc1187d736", "Live App Versions Testers 1"),
+    ExternalTesterGroup("a84bf09f-adf2-403e-a69e-8636cba7cedd", "External Testers 3"),
+    ExternalTesterGroup("71e65c76-50b3-412f-8f95-c0195e8716ee", "External Testers 4"),
+    ExternalTesterGroup("75de0034-ffe3-475d-bba9-73016808d473", "External Testers 5"),
     ExternalTesterGroup("3f5f1a35-dd71-4e11-8643-b20d0939c071", "Guardian Staff"))
 
   case class GitHubConfig(token: String)


### PR DESCRIPTION
## What does this change?

As part of the investigation into the incorrect articles bug on iOS, we recruited beta users to 3 new 'bug verification' tester groups. We no longer need them to help us verify the cause of the bug, so we want to start distributing the regular beta builds to them on the same schedule as External Testers 1. 

For now, we're keeping External Testers 2 as a group that we can submit experimental builds to, as per https://github.com/guardian/live-app-versions/pull/90. 

## How to test

When the next beta build goes out, the iosdeployments lambda should automatically add External Testers 1, External Testers 3, External Testers 4, External Testers 5, and Guardian Staff to that build, but not External Testers 2. 
