### PR TITLE
Add setup-scala GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          cache: sbt
-          java-version: 21
+      - name: Setup JDK and sbt
+        uses: guardian/setup-scala@v1
 
       - uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-21


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds the https://github.com/guardian/setup-scala action to make sbt available in the ci environment.
