### PR TITLE
iOS: Restore automatic release of betas to External Testers 2

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -110,23 +110,27 @@ object AppStoreConnectApi {
                   |  "data": [
                   |     {
                   |       "id": "${externalTesterConfig.group1.id}",
-                  |         "type": "betaGroups"
+                  |       "type": "betaGroups"
+                  |     },
+                  |     {
+                  |       "id": "${externalTesterConfig.group2.id}",
+                  |       "type": "betaGroups"
                   |     },
                   |     {
                   |       "id": "${externalTesterConfig.group3.id}",
-                  |         "type": "betaGroups"
+                  |       "type": "betaGroups"
                   |     },
                   |     {
                   |       "id": "${externalTesterConfig.group4.id}",
-                  |         "type": "betaGroups"
+                  |       "type": "betaGroups"
                   |     },
                   |     {
                   |       "id": "${externalTesterConfig.group5.id}",
-                  |         "type": "betaGroups"
+                  |       "type": "betaGroups"
                   |     },
                   |     {
                   |       "id": "${externalTesterConfig.group6.id}",
-                  |         "type": "betaGroups"
+                  |       "type": "betaGroups"
                   |     }
                   |  ]
                   |}
@@ -140,8 +144,8 @@ object AppStoreConnectApi {
       httpResponse <- Try(SharedClient.client.newCall(request).execute)
       _ <- SharedClient.getResponseBodyIfSuccessful("App Store Connect API", httpResponse)
     } yield {
-      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1}, ${externalTesterConfig.group3}, " +
-        s"${externalTesterConfig.group4}, ${externalTesterConfig.group5}, and ${externalTesterConfig.group6}")
+      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1}, ${externalTesterConfig.group2}, " +
+        s"${externalTesterConfig.group3}, ${externalTesterConfig.group4}, ${externalTesterConfig.group5}, and ${externalTesterConfig.group6}")
     }
   }
 

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -67,18 +67,21 @@ object Config {
 
   case class ExternalTesterGroup(id: String, name: String)
   case class ExternalTesterConfig(group1: ExternalTesterGroup,
+                                  group2: ExternalTesterGroup,
                                   group3: ExternalTesterGroup,
                                   group4: ExternalTesterGroup,
                                   group5: ExternalTesterGroup,
                                   group6: ExternalTesterGroup)
   val externalTesterConfigForProd = ExternalTesterConfig(
     ExternalTesterGroup("b3ee0d21-fe7e-487a-9f81-5ea993b6e860", "External Testers 1"),
+    ExternalTesterGroup("53ab9951-d444-4107-87ce-dbfbb2c898e5", "External Testers 2"),
     ExternalTesterGroup("a84bf09f-adf2-403e-a69e-8636cba7cedd", "External Testers 3"),
     ExternalTesterGroup("71e65c76-50b3-412f-8f95-c0195e8716ee", "External Testers 4"),
     ExternalTesterGroup("75de0034-ffe3-475d-bba9-73016808d473", "External Testers 5"),
     ExternalTesterGroup("3f5f1a35-dd71-4e11-8643-b20d0939c071", "Guardian Staff"))
   val externalTesterConfigForTesting = ExternalTesterConfig(
     ExternalTesterGroup("2c761621-6849-46c5-a936-fecc1187d736", "Live App Versions Testers 1"),
+    ExternalTesterGroup("d3fc87fc-7416-41ae-8ff9-2a1d8a6c619a", "Live App Versions Testers 2"),
     ExternalTesterGroup("a84bf09f-adf2-403e-a69e-8636cba7cedd", "External Testers 3"),
     ExternalTesterGroup("71e65c76-50b3-412f-8f95-c0195e8716ee", "External Testers 4"),
     ExternalTesterGroup("75de0034-ffe3-475d-bba9-73016808d473", "External Testers 5"),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

In https://github.com/guardian/live-app-versions/pull/90, we temporarily paused distributing our regular beta builds to one of our external beta tester groups, so that we could use that group specifically for testing Xcode 16 builds. That work is now complete, so we want to re-enable the automatic distribution of beta builds to group 2. 

## How to test

The next beta build is due to go out tonight. Once it has been approved by Apple, the iosdeployments lambda should automatically add External Testers 2 to that build, as well as External Testers 1, 3, 4, 5 and Guardian Staff. 
