### PR TITLE
Use Long instead of Int to model databaseId

### DIFF
--- a/src/main/scala/com/gu/githubapi/Conversion.scala
+++ b/src/main/scala/com/gu/githubapi/Conversion.scala
@@ -6,7 +6,7 @@ import com.gu.githubapi.GitHubApi.Deployment
 
 object Conversion {
 
-  case class RunningLiveAppDeployment(version: String, environment: String, gitHubDatabaseId: Int, createdAt: ZonedDateTime)
+  case class RunningLiveAppDeployment(version: String, environment: String, gitHubDatabaseId: Long, createdAt: ZonedDateTime)
 
   def runningLiveAppDeployments(gitHubDeployments: List[Deployment]): List[RunningLiveAppDeployment] = {
     gitHubDeployments

--- a/src/main/scala/com/gu/githubapi/GitHubApi.scala
+++ b/src/main/scala/com/gu/githubapi/GitHubApi.scala
@@ -20,7 +20,7 @@ object GitHubApi {
   case class GitHubApiException(message: String) extends Throwable(message: String)
 
   case class Node(node: Deployment)
-  case class Deployment(databaseId: Int, environment: String, state: String, latestStatus: Option[LatestStatus], createdAt: ZonedDateTime)
+  case class Deployment(databaseId: Long, environment: String, state: String, latestStatus: Option[LatestStatus], createdAt: ZonedDateTime)
   case class LatestStatus(description: Option[String])
 
   val deploymentsDecoder = Decoder[List[Node]].prepare(


### PR DESCRIPTION
## What does this change?

On Monday 27th January at 7pm, the ios-deployments lambda started reporting a [decoding failure](https://logs.gutools.co.uk/s/mobile/app/r/s/jc4NV):

![image](https://github.com/user-attachments/assets/f36817c3-2b36-438b-990d-8108eb3c9f36)

[Cloudwatch](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/ios-deployments-PROD?subtab=stateMachines&tab=monitoring) also clearly showed the failures in this lambda starting at the same time:

![image](https://github.com/user-attachments/assets/9ed283b5-c053-4a34-a719-6b97006f6ede)

The consequence of this was that beta builds uploaded to App Store Connect via a GitHub Action were not being submitted to Apple for review, or distributed to external testers.

The exact error being reported was:

```
[main] INFO com.gu.okhttp.SharedClient$ - Received successful response from GitHub API. Response code: 200
[main] ERROR com.gu.iosdeployments.Lambda$ - Failed to check deployment status due to: DecodingFailure at .data.repository.deployments.edges[6].node.databaseId: Int
DecodingFailure at .data.repository.deployments.edges[6].node.databaseId: Int
Exception in thread "main" DecodingFailure at .data.repository.deployments.edges[6].node.databaseId: Int
```

Running the lambda locally and using the debugger in IntelliJ to get the JSON for the response body from GitHub showed that the `databaseId` for the 7th node was 2,147,928,603. This is greater than the maximum 32-bit integer value of 2,147,483,647, which was causing an integer overflow issue. I've modified the `Deployment` case class to use a `Long` instead, which has a maximum value of 9,223,372,036,854,775,807. 

## How to test

I've verified that this change fixes the decoding failure by running the lambda locally. However, I then encountered an App Store Connect API error which I suspect is due to authentication issues caused by running locally, so I'm hoping to test this in the wild. New beta builds of the iOS app are automatically created and uploaded to App Store Connect every Monday and Wednesday evening. The ios-deployments lambda then submits them to Apple for review and distributes to external beta testers. We'll be able to see if this has fixed the problem by checking that the beta tester groups have been added to the next beta build, as in the screenshot below:

![image](https://github.com/user-attachments/assets/b175d8a8-284e-4527-948a-9824ccf2c7a2)

