### PR TITLE
Upgrade versions of netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,10 +33,10 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "2.0.16",
   "org.scalatest" %% "scalatest" % "3.2.19" % "test",
   "junit" % "junit" % "4.13.2",
-  "io.netty" % "netty-codec-http2" % "4.1.117.Final",
-  "io.netty" % "netty-handler-proxy" % "4.1.117.Final",
-  "io.netty" % "netty-resolver-dns" % "4.1.117.Final",
-  "io.netty" % "netty-transport-native-epoll" % "4.1.117.Final",
+  "io.netty" % "netty-codec-http2" % "4.1.118.Final",
+  "io.netty" % "netty-handler-proxy" % "4.1.118.Final",
+  "io.netty" % "netty-resolver-dns" % "4.1.118.Final",
+  "io.netty" % "netty-transport-native-epoll" % "4.1.118.Final",
   "com.fasterxml.jackson.core" % "jackson-core" % "2.18.2"
 )
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This upgrades the netty libraries to address these security notifications: https://github.com/guardian/live-app-versions/security/dependabot/1 and https://github.com/guardian/live-app-versions/security/dependabot/2
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
