### PR TITLE
iOS: Remove External Testers 2 from beta distribution

### DIFF
--- a/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
+++ b/src/main/scala/com/gu/appstoreconnectapi/AppStoreConnectApi.scala
@@ -113,10 +113,6 @@ object AppStoreConnectApi {
                   |       "type": "betaGroups"
                   |     },
                   |     {
-                  |       "id": "${externalTesterConfig.group2.id}",
-                  |       "type": "betaGroups"
-                  |     },
-                  |     {
                   |       "id": "${externalTesterConfig.group3.id}",
                   |       "type": "betaGroups"
                   |     },
@@ -144,7 +140,7 @@ object AppStoreConnectApi {
       httpResponse <- Try(SharedClient.client.newCall(request).execute)
       _ <- SharedClient.getResponseBodyIfSuccessful("App Store Connect API", httpResponse)
     } yield {
-      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1}, ${externalTesterConfig.group2}, " +
+      logger.info(s"Successfully distributed build to ${externalTesterConfig.group1}, " +
         s"${externalTesterConfig.group3}, ${externalTesterConfig.group4}, ${externalTesterConfig.group5}, and ${externalTesterConfig.group6}")
     }
   }

--- a/src/main/scala/com/gu/config/Config.scala
+++ b/src/main/scala/com/gu/config/Config.scala
@@ -84,21 +84,18 @@ object Config {
   case class ExternalTesterGroup(id: String, name: String)
   case class ExternalTesterConfig(
     group1: ExternalTesterGroup,
-    group2: ExternalTesterGroup,
     group3: ExternalTesterGroup,
     group4: ExternalTesterGroup,
     group5: ExternalTesterGroup,
     group6: ExternalTesterGroup)
   val externalTesterConfigForProd = ExternalTesterConfig(
     ExternalTesterGroup("b3ee0d21-fe7e-487a-9f81-5ea993b6e860", "External Testers 1"),
-    ExternalTesterGroup("53ab9951-d444-4107-87ce-dbfbb2c898e5", "External Testers 2"),
     ExternalTesterGroup("a84bf09f-adf2-403e-a69e-8636cba7cedd", "External Testers 3"),
     ExternalTesterGroup("71e65c76-50b3-412f-8f95-c0195e8716ee", "External Testers 4"),
     ExternalTesterGroup("75de0034-ffe3-475d-bba9-73016808d473", "External Testers 5"),
     ExternalTesterGroup("3f5f1a35-dd71-4e11-8643-b20d0939c071", "Guardian Staff"))
   val externalTesterConfigForTesting = ExternalTesterConfig(
     ExternalTesterGroup("2c761621-6849-46c5-a936-fecc1187d736", "Live App Versions Testers 1"),
-    ExternalTesterGroup("d3fc87fc-7416-41ae-8ff9-2a1d8a6c619a", "Live App Versions Testers 2"),
     ExternalTesterGroup("a84bf09f-adf2-403e-a69e-8636cba7cedd", "External Testers 3"),
     ExternalTesterGroup("71e65c76-50b3-412f-8f95-c0195e8716ee", "External Testers 4"),
     ExternalTesterGroup("75de0034-ffe3-475d-bba9-73016808d473", "External Testers 5"),


### PR DESCRIPTION
Reverts guardian/live-app-versions#198

but essentially it is re-applying the changes in: https://github.com/guardian/live-app-versions/pull/184

This will allow us to test some experimental fixes to an ongoing issue where the app can hang and be terminated by the system when users navigate to the Puzzles hub.

Once the testing is complete, I'll revert this change so that the testing group will rejoin the usual beta distribution.

## How to test

The next beta build is due to go out on Wednesday evening. The `iosdeployments` lambda should automatically add External Testers 1, 3, 4, 5, and Guardian Staff to that build, but not External Testers 2. Furthermore, once we create the Navigation beta manually and upload it to App Store Connect, this lambda should not add External Testers 1, 3, 4, 5, and Guardian Staff to that build.